### PR TITLE
Add parallel work support to project skill

### DIFF
--- a/.claude/skills/project/SKILL.md
+++ b/.claude/skills/project/SKILL.md
@@ -1,89 +1,107 @@
 ---
 name: project
 description: |
-  Assess route-agent project status and find next tasks. Use when starting work, checking progress, deciding what to work on, or asking "what's next?"
+  Manage route-agent project: check status, find next tasks, spawn parallel work. Use when starting work, checking progress, or asking "what's next?"
 allowed-tools:
   - Bash(gh:*)
+  - Bash(git:*)
   - mcp__github
+  - Task
 ---
 
 # Project Management
 
-Assess project status and find ready tasks from GitHub issues.
-
-## Quick Start
-
-**Status check:**
-```bash
-gh api repos/bendrucker/route-agent/milestones --jq '.[] | "\(.title): \(.closed_issues)/\(.open_issues + .closed_issues)"'
-```
-
-**Find ready tasks:**
-```bash
-gh issue list --repo bendrucker/route-agent --state open --json number,title,milestone,body --limit 100
-```
+Assess project status, find ready tasks, and orchestrate parallel work.
 
 ## Commands
 
 | Command | Action |
 |---------|--------|
 | `/project` | Show milestone progress and ready tasks |
-| `/project next` | Recommend single next task to work on |
-| `/project <milestone>` | Show issues for specific milestone |
+| `/project next` | Recommend single next task |
+| `/project work` | Spawn sub-agents for ready tasks (parallel) |
+| `/project work #N` | Work on specific issue |
+| `/project cleanup` | Remove worktrees for merged PRs |
 
-## Workflow
+## Quick Start
 
-1. **Fetch state** - Get open issues and milestone progress
-2. **Parse dependencies** - Check "Depends On" sections in issue bodies
-3. **Find ready tasks** - Issues where all dependencies are closed
-4. **Prioritize** - Earlier milestones first
+```bash
+# Milestone progress
+gh api repos/bendrucker/route-agent/milestones --jq '.[] | "\(.title): \(.closed_issues)/\(.open_issues + .closed_issues)"'
 
-## Dependency Resolution
+# Open issues
+gh issue list --repo bendrucker/route-agent --state open --json number,title,milestone,body --limit 100
+```
 
-Issues express dependencies in body text:
+## Finding Ready Tasks
+
+**Ready** = No "Depends On" section, OR all dependencies closed.
+
+Parse from issue body:
 ```markdown
 ## Depends On
 - Issue title here
-- Another issue title
 ```
 
-**Ready**: No "Depends On" section, OR all listed issues are closed.
+## Parallel Work (`/project work`)
+
+1. **Find ready tasks** - Parse dependencies, filter unblocked
+2. **Create worktrees** - One per issue in `~/.worktrees/route-agent/<N>/`
+3. **Spawn sub-agents** - Each works in background, creates PR
+4. **Report** - List spawned agents for monitoring
+
+See [references/worktrees.md](references/worktrees.md) for details.
+
+### Sub-Agent Prompt
+
+```
+Work on issue #N in worktree at <path>.
+
+Issue: <title>
+<body>
+
+1. cd to worktree
+2. Read CLAUDE.md and relevant docs
+3. Implement requirements
+4. Commit with descriptive message
+5. Push and create PR with "Closes #N"
+6. Return PR URL
+```
 
 ## Milestone Priority
 
 1. Foundation
-2. Eval Setup (parallel with Foundation)
+2. Eval Setup (parallel)
 3. Strava Integration
 4. GraphHopper Integration
 5. Route Synthesis
 6. Place Search, Water Stops, Climb Integration, Weather Integration
-7. Ride Preparation
-8. Narrative Research
-9. Research Quality
-10. Route Refinement
-11. Evaluation Framework
+7. Ride Preparation, Narrative Research
+8. Research Quality, Route Refinement
+9. Evaluation Framework
 
-## Output Examples
+## Output
 
 **Status:**
 ```
 ## Project Status
 
-### Foundation (1/2 complete)
-- [x] #2 Claude Agent SDK project structure
+### Foundation (1/2)
+- [x] #2 SDK project structure
 - [ ] #3 Checkpoint system - READY
 
-### Eval Setup (0/2 complete)
-- [ ] #4 Promptfoo setup - READY
-- [ ] #5 Eval directory structure - blocked by #4
+### Ready (2)
+- #3 Checkpoint system (Foundation)
+- #4 Promptfoo setup (Eval Setup)
 ```
 
-**Next task:**
+**Work:**
 ```
-## Next Task: #3 Checkpoint system
+## Parallel Work
 
-**Milestone**: Foundation
-**Status**: Ready (no blockers)
+Spawning:
+- #3 Checkpoint system → worktree created, agent launched
+- #4 Promptfoo setup → worktree created, agent launched
 
-Integrate AskUserQuestion for structured checkpoints...
+Monitor with /tasks. PRs appear for review.
 ```

--- a/.claude/skills/project/references/worktrees.md
+++ b/.claude/skills/project/references/worktrees.md
@@ -1,0 +1,71 @@
+# Git Worktrees for Parallel Work
+
+## Overview
+
+Use git worktrees to work on multiple issues in parallel. Each worktree is an independent checkout with its own branch.
+
+## Worktree Location
+
+Store worktrees in `~/.worktrees/<repo>/<issue-number>/`:
+
+```bash
+REPO_NAME=$(basename $(git rev-parse --show-toplevel))
+WORKTREE_PATH=~/.worktrees/$REPO_NAME/$ISSUE
+```
+
+## Lifecycle
+
+### 1. Create Worktree
+
+```bash
+ISSUE=5
+REPO_NAME=$(basename $(git rev-parse --show-toplevel))
+WORKTREE_PATH=~/.worktrees/$REPO_NAME/$ISSUE
+
+git fetch origin main
+git worktree add "$WORKTREE_PATH" -b "issue-$ISSUE" origin/main
+```
+
+### 2. Work in Worktree
+
+Sub-agent runs with working directory set to the worktree path.
+
+### 3. Create PR
+
+```bash
+cd "$WORKTREE_PATH"
+git push -u origin "issue-$ISSUE"
+gh pr create --title "..." --body "Closes #$ISSUE"
+```
+
+### 4. Cleanup (After PR Merged)
+
+```bash
+git worktree remove "$WORKTREE_PATH"
+git branch -d "issue-$ISSUE"
+```
+
+## Cleanup Strategy
+
+Cleanup is **lazy** - only run when explicitly requested via `/project cleanup`.
+
+### `/project cleanup`
+
+```bash
+REPO_NAME=$(basename $(git rev-parse --show-toplevel))
+git worktree list | grep "$REPO_NAME" | while read path _ branch; do
+  ISSUE=$(echo "$branch" | sed 's/.*issue-//')
+  if gh issue view "$ISSUE" --json state --jq '.state' | grep -q CLOSED; then
+    git worktree remove "$path"
+  fi
+done
+git worktree prune
+```
+
+## Conventions
+
+- **Branch naming**: `issue-<number>` (e.g., `issue-5`)
+- **Worktree path**: `~/.worktrees/<repo>/<issue-number>/`
+- **One issue per worktree**: Don't mix concerns
+- **PR links issue**: Include "Closes #N" in PR body
+- **Lazy cleanup**: Run `/project cleanup` periodically


### PR DESCRIPTION
Adds `/project work` command for spawning parallel sub-agents:

- Each issue gets its own git worktree
- Sub-agents work in background, create PRs
- Lazy cleanup via `/project cleanup`

## Commands
- `/project work` - Spawn agents for all ready tasks
- `/project work #N` - Work on specific issue  
- `/project cleanup` - Remove worktrees for merged PRs