### PR TITLE
Add History Analysis skill (#7)

### DIFF
--- a/src/osm/osm.test.ts
+++ b/src/osm/osm.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { findCyclingInfrastructure, findWaterSources, querySurfaceTypes } from "./overpass";
 
-describe("findWaterSources", () => {
+const live = describe.skipIf(!process.env.LIVE_API);
+
+live("findWaterSources", () => {
   test("Pantoll Ranger Station area", async () => {
     const results = await findWaterSources({
       south: 37.9015,
@@ -13,7 +15,7 @@ describe("findWaterSources", () => {
   }, 15000);
 });
 
-describe("findCyclingInfrastructure", () => {
+live("findCyclingInfrastructure", () => {
   test("Sausalito near Bridgeway", async () => {
     const results = await findCyclingInfrastructure({
       south: 37.855,
@@ -25,7 +27,7 @@ describe("findCyclingInfrastructure", () => {
   }, 15000);
 });
 
-describe("querySurfaceTypes", () => {
+live("querySurfaceTypes", () => {
   test("Mill Valley - Sausalito bike path", async () => {
     const results = await querySurfaceTypes({
       south: 37.86,

--- a/src/skills/history-analysis/analyze.ts
+++ b/src/skills/history-analysis/analyze.ts
@@ -3,7 +3,6 @@ import type {
   GeographicBounds,
   HistoryAnalysisInput,
   HistoryAnalysisOutput,
-  RidingPreferences,
 } from "./types";
 
 function isWithinBounds(latLng: [number, number], bounds: GeographicBounds): boolean {
@@ -20,50 +19,10 @@ function filterActivitiesByArea(
   return activities.filter((a) => isWithinBounds(a.startLatLng, bounds));
 }
 
-function describeFamiliarRoads(activities: ActivitySummary[]): string[] {
-  if (activities.length === 0) return [];
-  return activities.map(
-    (a) => `${a.name} (${(a.distance / 1000).toFixed(1)}km, ${a.elevationGain}m gain)`,
-  );
-}
-
-function describeNewOpportunities(activitiesInArea: ActivitySummary[]): string[] {
-  if (activitiesInArea.length === 0) {
-    return ["No prior rides in this area — entirely new territory to explore"];
-  }
-  if (activitiesInArea.length < 3) {
-    return ["Few rides in this area — likely many unexplored roads nearby"];
-  }
-  return [];
-}
-
-function computePreferences(activities: ActivitySummary[]): RidingPreferences {
-  if (activities.length === 0) {
-    return { avgDistance: 0, avgElevation: 0, avgDuration: 0 };
-  }
-
-  const totalDistance = activities.reduce((sum, a) => sum + a.distance, 0);
-  const totalElevation = activities.reduce((sum, a) => sum + a.elevationGain, 0);
-  const totalDuration = activities.reduce((sum, a) => sum + a.movingTime, 0);
-
-  return {
-    avgDistance: totalDistance / activities.length,
-    avgElevation: totalElevation / activities.length,
-    avgDuration: totalDuration / activities.length,
-  };
-}
-
 export function analyzeHistory(input: HistoryAnalysisInput): HistoryAnalysisOutput {
-  const relevantActivities = filterActivitiesByArea(input.activities, input.area);
-  const familiarRoads = describeFamiliarRoads(relevantActivities);
-  const newOpportunities = describeNewOpportunities(relevantActivities);
-  const preferences = computePreferences(input.activities);
-
   return {
-    relevantActivities,
+    relevantActivities: filterActivitiesByArea(input.activities, input.area),
     reusableSegments: input.segments,
-    familiarRoads,
-    newOpportunities,
-    preferences,
+    preferences: input.preferences,
   };
 }

--- a/src/skills/history-analysis/analyze.ts
+++ b/src/skills/history-analysis/analyze.ts
@@ -1,0 +1,69 @@
+import type {
+  ActivitySummary,
+  GeographicBounds,
+  HistoryAnalysisInput,
+  HistoryAnalysisOutput,
+  RidingPreferences,
+} from "./types";
+
+function isWithinBounds(latLng: [number, number], bounds: GeographicBounds): boolean {
+  const [lat, lng] = latLng;
+  return (
+    lat >= bounds.sw.lat && lat <= bounds.ne.lat && lng >= bounds.sw.lng && lng <= bounds.ne.lng
+  );
+}
+
+function filterActivitiesByArea(
+  activities: ActivitySummary[],
+  bounds: GeographicBounds,
+): ActivitySummary[] {
+  return activities.filter((a) => isWithinBounds(a.startLatLng, bounds));
+}
+
+function describeFamiliarRoads(activities: ActivitySummary[]): string[] {
+  if (activities.length === 0) return [];
+  return activities.map(
+    (a) => `${a.name} (${(a.distance / 1000).toFixed(1)}km, ${a.elevationGain}m gain)`,
+  );
+}
+
+function describeNewOpportunities(activitiesInArea: ActivitySummary[]): string[] {
+  if (activitiesInArea.length === 0) {
+    return ["No prior rides in this area — entirely new territory to explore"];
+  }
+  if (activitiesInArea.length < 3) {
+    return ["Few rides in this area — likely many unexplored roads nearby"];
+  }
+  return [];
+}
+
+function computePreferences(activities: ActivitySummary[]): RidingPreferences {
+  if (activities.length === 0) {
+    return { avgDistance: 0, avgElevation: 0, avgDuration: 0 };
+  }
+
+  const totalDistance = activities.reduce((sum, a) => sum + a.distance, 0);
+  const totalElevation = activities.reduce((sum, a) => sum + a.elevationGain, 0);
+  const totalDuration = activities.reduce((sum, a) => sum + a.movingTime, 0);
+
+  return {
+    avgDistance: totalDistance / activities.length,
+    avgElevation: totalElevation / activities.length,
+    avgDuration: totalDuration / activities.length,
+  };
+}
+
+export function analyzeHistory(input: HistoryAnalysisInput): HistoryAnalysisOutput {
+  const relevantActivities = filterActivitiesByArea(input.activities, input.area);
+  const familiarRoads = describeFamiliarRoads(relevantActivities);
+  const newOpportunities = describeNewOpportunities(relevantActivities);
+  const preferences = computePreferences(input.activities);
+
+  return {
+    relevantActivities,
+    reusableSegments: input.segments,
+    familiarRoads,
+    newOpportunities,
+    preferences,
+  };
+}

--- a/src/skills/history-analysis/evals/cases/scenarios.yaml
+++ b/src/skills/history-analysis/evals/cases/scenarios.yaml
@@ -1,0 +1,91 @@
+- description: "New territory — no prior rides in area"
+  vars:
+    history_prompt: |-
+      Analyze this cyclist's ride history to inform route planning. Use familiar roads as reliable building blocks and flag new territory as exploration opportunities.
+
+      No prior rides in this area — all roads are new. Prioritize well-known routes and flag uncertainty about conditions.
+    analysis_data: |
+      {
+        "relevantActivities": [],
+        "reusableSegments": [],
+        "familiarRoads": [],
+        "newOpportunities": ["No prior rides in this area — entirely new territory to explore"],
+        "preferences": { "avgDistance": 72000, "avgElevation": 1100, "avgDuration": 10800 }
+      }
+    query: "Plan a 60km ride around Santa Cruz"
+  assert:
+    - type: llm-rubric
+      value: |
+        The response should:
+        - Acknowledge that the rider has no prior rides in this area
+        - Express appropriate caution about unfamiliar roads or conditions
+        - NOT claim familiarity with roads the rider hasn't ridden
+
+
+- description: "Familiar area — Marin County with segments"
+  vars:
+    history_prompt: |-
+      Analyze this cyclist's ride history to inform route planning. Use familiar roads as reliable building blocks and flag new territory as exploration opportunities.
+
+      2 known segments available — prefer incorporating these as they mark interesting road sections with benchmark data.
+    analysis_data: |
+      {
+        "relevantActivities": [
+          { "id": 12345, "name": "Mt Tam via Panoramic Highway", "distance": 65000, "elevationGain": 1200, "movingTime": 10800, "startLatLng": [37.906, -122.5474] },
+          { "id": 12346, "name": "Hawk Hill and Marin Headlands", "distance": 42000, "elevationGain": 750, "movingTime": 7200, "startLatLng": [37.8577, -122.4853] },
+          { "id": 12347, "name": "Camino Alto to Paradise Loop", "distance": 55000, "elevationGain": 600, "movingTime": 9000, "startLatLng": [37.906, -122.5474] }
+        ],
+        "reusableSegments": [
+          { "id": 98765, "name": "Hawk Hill Climb", "distance": 2100, "avgGrade": 8.5, "elevDifference": 178 },
+          { "id": 98766, "name": "Panoramic Highway to Pantoll", "distance": 5200, "avgGrade": 5.8, "elevDifference": 302 }
+        ],
+        "familiarRoads": [
+          "Mt Tam via Panoramic Highway (65.0km, 1200m gain)",
+          "Hawk Hill and Marin Headlands (42.0km, 750m gain)",
+          "Camino Alto to Paradise Loop (55.0km, 600m gain)"
+        ],
+        "newOpportunities": [],
+        "preferences": { "avgDistance": 54000, "avgElevation": 850, "avgDuration": 9000 }
+      }
+    query: "Plan a hilly 60km ride from Mill Valley"
+  assert:
+    - type: llm-rubric
+      value: |
+        The response should:
+        - Reference specific roads or segments the rider has ridden before (e.g. Panoramic Highway, Hawk Hill, Camino Alto)
+        - Suggest incorporating known segments as route building blocks
+        - Treat the rider's history as an asset for planning, not a constraint
+
+
+- description: "Few rides — partial Marin coverage"
+  vars:
+    history_prompt: |-
+      Analyze this cyclist's ride history to inform route planning. Use familiar roads as reliable building blocks and flag new territory as exploration opportunities.
+
+      Few prior rides in this area. Mix familiar roads with new ones for a balanced route.
+
+      1 known segments available — prefer incorporating these as they mark interesting road sections with benchmark data.
+    analysis_data: |
+      {
+        "relevantActivities": [
+          { "id": 12345, "name": "Mill Valley to Sausalito via bike path", "distance": 25000, "elevationGain": 200, "movingTime": 4500, "startLatLng": [37.906, -122.5474] }
+        ],
+        "reusableSegments": [
+          { "id": 98765, "name": "Mill Valley - Sausalito Path", "distance": 6200, "avgGrade": 0.5, "elevDifference": 31 }
+        ],
+        "familiarRoads": [
+          "Mill Valley to Sausalito via bike path (25.0km, 200m gain)"
+        ],
+        "newOpportunities": ["Few rides in this area — likely many unexplored roads nearby"],
+        "preferences": { "avgDistance": 25000, "avgElevation": 200, "avgDuration": 4500 }
+      }
+    query: "Plan a 50km ride exploring Mt Tam from Mill Valley"
+  assert:
+    - type: llm-rubric
+      value: |
+        The response should:
+        - Acknowledge limited but existing familiarity with the area
+        - Reference the known Mill Valley - Sausalito bike path
+        - Suggest exploring new roads beyond what the rider has already done, such as climbing Mt Tam
+        - Balance reusing the known bike path segment with discovering new territory
+

--- a/src/skills/history-analysis/evals/cases/scenarios.yaml
+++ b/src/skills/history-analysis/evals/cases/scenarios.yaml
@@ -8,9 +8,7 @@
       {
         "relevantActivities": [],
         "reusableSegments": [],
-        "familiarRoads": [],
-        "newOpportunities": ["No prior rides in this area — entirely new territory to explore"],
-        "preferences": { "avgDistance": 72000, "avgElevation": 1100, "avgDuration": 10800 }
+        "preferences": { "rideCount": 0, "distance": { "avg": 72000, "max": 160000 }, "elevation": { "avg": 1100, "max": 2500 }, "duration": { "avg": 10800, "max": 21600 } }
       }
     query: "Plan a 60km ride around Santa Cruz"
   assert:
@@ -20,7 +18,6 @@
         - Acknowledge that the rider has no prior rides in this area
         - Express appropriate caution about unfamiliar roads or conditions
         - NOT claim familiarity with roads the rider hasn't ridden
-
 
 - description: "Familiar area — Marin County with segments"
   vars:
@@ -39,13 +36,7 @@
           { "id": 98765, "name": "Hawk Hill Climb", "distance": 2100, "avgGrade": 8.5, "elevDifference": 178 },
           { "id": 98766, "name": "Panoramic Highway to Pantoll", "distance": 5200, "avgGrade": 5.8, "elevDifference": 302 }
         ],
-        "familiarRoads": [
-          "Mt Tam via Panoramic Highway (65.0km, 1200m gain)",
-          "Hawk Hill and Marin Headlands (42.0km, 750m gain)",
-          "Camino Alto to Paradise Loop (55.0km, 600m gain)"
-        ],
-        "newOpportunities": [],
-        "preferences": { "avgDistance": 54000, "avgElevation": 850, "avgDuration": 9000 }
+        "preferences": { "rideCount": 150, "distance": { "avg": 54000, "max": 110000 }, "elevation": { "avg": 850, "max": 2200 }, "duration": { "avg": 9000, "max": 18000 } }
       }
     query: "Plan a hilly 60km ride from Mill Valley"
   assert:
@@ -55,7 +46,6 @@
         - Reference specific roads or segments the rider has ridden before (e.g. Panoramic Highway, Hawk Hill, Camino Alto)
         - Suggest incorporating known segments as route building blocks
         - Treat the rider's history as an asset for planning, not a constraint
-
 
 - description: "Few rides — partial Marin coverage"
   vars:
@@ -73,11 +63,7 @@
         "reusableSegments": [
           { "id": 98765, "name": "Mill Valley - Sausalito Path", "distance": 6200, "avgGrade": 0.5, "elevDifference": 31 }
         ],
-        "familiarRoads": [
-          "Mill Valley to Sausalito via bike path (25.0km, 200m gain)"
-        ],
-        "newOpportunities": ["Few rides in this area — likely many unexplored roads nearby"],
-        "preferences": { "avgDistance": 25000, "avgElevation": 200, "avgDuration": 4500 }
+        "preferences": { "rideCount": 5, "distance": { "avg": 25000, "max": 35000 }, "elevation": { "avg": 200, "max": 400 }, "duration": { "avg": 4500, "max": 7200 } }
       }
     query: "Plan a 50km ride exploring Mt Tam from Mill Valley"
   assert:
@@ -88,4 +74,3 @@
         - Reference the known Mill Valley - Sausalito bike path
         - Suggest exploring new roads beyond what the rider has already done, such as climbing Mt Tam
         - Balance reusing the known bike path segment with discovering new territory
-

--- a/src/skills/history-analysis/evals/prompt.txt
+++ b/src/skills/history-analysis/evals/prompt.txt
@@ -1,0 +1,13 @@
+{{history_prompt}}
+
+## Analysis Data
+
+```json
+{{analysis_data}}
+```
+
+## Route Planning Request
+
+{{query}}
+
+Based on the history analysis above, provide route planning guidance for this request. Focus on how the rider's history should inform the route plan.

--- a/src/skills/history-analysis/evals/promptfooconfig.yaml
+++ b/src/skills/history-analysis/evals/promptfooconfig.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: "History analysis skill — does the prompt produce useful route planning guidance?"
+
+prompts:
+  - file://prompt.txt
+
+providers:
+  - id: anthropic:messages:claude-sonnet-4-6
+    config:
+      temperature: 0.0
+      max_tokens: 1024
+
+defaultTest:
+  options:
+    provider: anthropic:messages:claude-sonnet-4-6
+
+tests: file://cases/scenarios.yaml

--- a/src/skills/history-analysis/history-analysis.test.ts
+++ b/src/skills/history-analysis/history-analysis.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "bun:test";
+import { analyzeHistory } from "./analyze";
+import { historyAnalysisPrompt } from "./prompt";
+import type {
+  ActivitySummary,
+  GeographicBounds,
+  HistoryAnalysisInput,
+  SegmentSummary,
+} from "./types";
+
+const paloAltoArea: GeographicBounds = {
+  sw: { lat: 37.3, lng: -122.2 },
+  ne: { lat: 37.5, lng: -122.0 },
+};
+
+const sacramentoArea: GeographicBounds = {
+  sw: { lat: 38.4, lng: -121.6 },
+  ne: { lat: 38.7, lng: -121.3 },
+};
+
+const activities: ActivitySummary[] = [
+  {
+    id: 12345,
+    name: "Pescadero Loop via Tunitas Creek",
+    distance: 105000,
+    elevationGain: 1800,
+    movingTime: 14400,
+    startLatLng: [37.4419, -122.143],
+  },
+  {
+    id: 12346,
+    name: "Conservatory Drive Climb",
+    distance: 45000,
+    elevationGain: 900,
+    movingTime: 7200,
+    startLatLng: [37.4419, -122.143],
+  },
+];
+
+const segments: SegmentSummary[] = [
+  {
+    id: 98765,
+    name: "Tunitas Creek Road Climb",
+    distance: 8500,
+    avgGrade: 5.2,
+    elevDifference: 442,
+  },
+  {
+    id: 98766,
+    name: "Stage Road South",
+    distance: 12000,
+    avgGrade: 2.1,
+    elevDifference: 252,
+  },
+];
+
+const routes = [
+  { id: 55555, name: "Pescadero Lunch Ride", distance: 105000, elevationGain: 1800 },
+  { id: 55556, name: "Quick Conservatory Loop", distance: 45000, elevationGain: 900 },
+];
+
+function createInput(area: GeographicBounds): HistoryAnalysisInput {
+  return { area, activities, segments, routes };
+}
+
+describe("analyzeHistory", () => {
+  test("filters activities within the bounding box", () => {
+    const result = analyzeHistory(createInput(paloAltoArea));
+    expect(result.relevantActivities).toHaveLength(2);
+    expect(result.relevantActivities.map((a) => a.id)).toEqual([12345, 12346]);
+  });
+
+  test("returns no relevant activities for an area with no rides", () => {
+    const result = analyzeHistory(createInput(sacramentoArea));
+    expect(result.relevantActivities).toHaveLength(0);
+  });
+
+  test("passes all segments through as reusable", () => {
+    const result = analyzeHistory(createInput(paloAltoArea));
+    expect(result.reusableSegments).toEqual(segments);
+  });
+
+  test("describes familiar roads from matching activities", () => {
+    const result = analyzeHistory(createInput(paloAltoArea));
+    expect(result.familiarRoads).toHaveLength(2);
+    expect(result.familiarRoads[0]).toContain("Pescadero Loop via Tunitas Creek");
+    expect(result.familiarRoads[0]).toContain("105.0km");
+    expect(result.familiarRoads[0]).toContain("1800m gain");
+  });
+
+  test("reports new territory when no activities match", () => {
+    const result = analyzeHistory(createInput(sacramentoArea));
+    expect(result.familiarRoads).toHaveLength(0);
+    expect(result.newOpportunities).toHaveLength(1);
+    expect(result.newOpportunities[0]).toContain("new territory");
+  });
+
+  test("reports few rides when under threshold", () => {
+    const singleActivity: ActivitySummary[] = [activities[0]];
+    const result = analyzeHistory({
+      area: paloAltoArea,
+      activities: singleActivity,
+      segments,
+      routes,
+    });
+    expect(result.newOpportunities).toHaveLength(1);
+    expect(result.newOpportunities[0]).toContain("Few rides");
+  });
+
+  test("reports no new opportunities when area is well-covered", () => {
+    const manyActivities: ActivitySummary[] = [
+      ...activities,
+      { ...activities[0], id: 12347, name: "Morning Ride" },
+    ];
+    const result = analyzeHistory({
+      area: paloAltoArea,
+      activities: manyActivities,
+      segments,
+      routes,
+    });
+    expect(result.newOpportunities).toHaveLength(0);
+  });
+
+  test("computes preferences from all activities", () => {
+    const result = analyzeHistory(createInput(paloAltoArea));
+    expect(result.preferences.avgDistance).toBe(75000);
+    expect(result.preferences.avgElevation).toBe(1350);
+    expect(result.preferences.avgDuration).toBe(10800);
+  });
+
+  test("computes preferences even when no activities match the area", () => {
+    const result = analyzeHistory(createInput(sacramentoArea));
+    expect(result.preferences.avgDistance).toBe(75000);
+    expect(result.preferences.avgElevation).toBe(1350);
+  });
+
+  test("handles empty activities", () => {
+    const result = analyzeHistory({
+      area: paloAltoArea,
+      activities: [],
+      segments: [],
+      routes: [],
+    });
+    expect(result.relevantActivities).toHaveLength(0);
+    expect(result.reusableSegments).toHaveLength(0);
+    expect(result.familiarRoads).toHaveLength(0);
+    expect(result.newOpportunities).toHaveLength(1);
+    expect(result.preferences.avgDistance).toBe(0);
+    expect(result.preferences.avgElevation).toBe(0);
+    expect(result.preferences.avgDuration).toBe(0);
+  });
+});
+
+describe("historyAnalysisPrompt", () => {
+  test("exports a non-empty prompt string", () => {
+    expect(typeof historyAnalysisPrompt).toBe("string");
+    expect(historyAnalysisPrompt.length).toBeGreaterThan(0);
+  });
+
+  test("covers key domain concepts", () => {
+    expect(historyAnalysisPrompt).toContain("familiar");
+    expect(historyAnalysisPrompt).toContain("New territory");
+    expect(historyAnalysisPrompt).toContain("preferences");
+    expect(historyAnalysisPrompt).toContain("segment");
+  });
+});

--- a/src/skills/history-analysis/history-analysis.test.ts
+++ b/src/skills/history-analysis/history-analysis.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { analyzeHistory } from "./analyze";
-import { historyAnalysisPrompt } from "./prompt";
+import { buildHistoryPrompt } from "./prompt";
 import type {
   ActivitySummary,
   GeographicBounds,
@@ -151,16 +151,49 @@ describe("analyzeHistory", () => {
   });
 });
 
-describe("historyAnalysisPrompt", () => {
-  test("exports a non-empty prompt string", () => {
-    expect(typeof historyAnalysisPrompt).toBe("string");
-    expect(historyAnalysisPrompt.length).toBeGreaterThan(0);
+describe("buildHistoryPrompt", () => {
+  test("includes familiarity context for new territory", () => {
+    const output = analyzeHistory(createInput(sacramentoArea));
+    const prompt = buildHistoryPrompt(output);
+    expect(prompt).toContain("No prior rides");
   });
 
-  test("covers key domain concepts", () => {
-    expect(historyAnalysisPrompt).toContain("familiar");
-    expect(historyAnalysisPrompt).toContain("New territory");
-    expect(historyAnalysisPrompt).toContain("preferences");
-    expect(historyAnalysisPrompt).toContain("segment");
+  test("includes familiarity context for few rides", () => {
+    const output = analyzeHistory({
+      area: paloAltoArea,
+      activities: [activities[0]],
+      segments,
+      routes,
+    });
+    const prompt = buildHistoryPrompt(output);
+    expect(prompt).toContain("Few prior rides");
+  });
+
+  test("omits familiarity context for well-covered area", () => {
+    const output = analyzeHistory({
+      area: paloAltoArea,
+      activities: [...activities, { ...activities[0], id: 12347, name: "Morning Ride" }],
+      segments,
+      routes,
+    });
+    const prompt = buildHistoryPrompt(output);
+    expect(prompt).not.toContain("prior rides");
+  });
+
+  test("includes segment context when segments exist", () => {
+    const output = analyzeHistory(createInput(paloAltoArea));
+    const prompt = buildHistoryPrompt(output);
+    expect(prompt).toContain("2 known segments");
+  });
+
+  test("omits segment context when no segments", () => {
+    const output = analyzeHistory({
+      area: paloAltoArea,
+      activities,
+      segments: [],
+      routes,
+    });
+    const prompt = buildHistoryPrompt(output);
+    expect(prompt).not.toContain("segments");
   });
 });

--- a/src/skills/history-analysis/history-analysis.test.ts
+++ b/src/skills/history-analysis/history-analysis.test.ts
@@ -8,55 +8,55 @@ import type {
   SegmentSummary,
 } from "./types";
 
-const paloAltoArea: GeographicBounds = {
-  sw: { lat: 37.3, lng: -122.2 },
-  ne: { lat: 37.5, lng: -122.0 },
+const marinArea: GeographicBounds = {
+  sw: { lat: 37.82, lng: -122.6 },
+  ne: { lat: 37.95, lng: -122.45 },
 };
 
-const sacramentoArea: GeographicBounds = {
-  sw: { lat: 38.4, lng: -121.6 },
-  ne: { lat: 38.7, lng: -121.3 },
+const santaCruzArea: GeographicBounds = {
+  sw: { lat: 36.9, lng: -122.1 },
+  ne: { lat: 37.0, lng: -121.9 },
 };
 
 const activities: ActivitySummary[] = [
   {
     id: 12345,
-    name: "Pescadero Loop via Tunitas Creek",
-    distance: 105000,
-    elevationGain: 1800,
-    movingTime: 14400,
-    startLatLng: [37.4419, -122.143],
+    name: "Mt Tam via Panoramic Highway",
+    distance: 65000,
+    elevationGain: 1200,
+    movingTime: 10800,
+    startLatLng: [37.906, -122.5474],
   },
   {
     id: 12346,
-    name: "Conservatory Drive Climb",
-    distance: 45000,
-    elevationGain: 900,
+    name: "Hawk Hill and Marin Headlands",
+    distance: 42000,
+    elevationGain: 750,
     movingTime: 7200,
-    startLatLng: [37.4419, -122.143],
+    startLatLng: [37.8577, -122.4853],
   },
 ];
 
 const segments: SegmentSummary[] = [
   {
     id: 98765,
-    name: "Tunitas Creek Road Climb",
-    distance: 8500,
-    avgGrade: 5.2,
-    elevDifference: 442,
+    name: "Hawk Hill Climb",
+    distance: 2100,
+    avgGrade: 8.5,
+    elevDifference: 178,
   },
   {
     id: 98766,
-    name: "Stage Road South",
-    distance: 12000,
-    avgGrade: 2.1,
-    elevDifference: 252,
+    name: "Panoramic Highway to Pantoll",
+    distance: 5200,
+    avgGrade: 5.8,
+    elevDifference: 302,
   },
 ];
 
 const routes = [
-  { id: 55555, name: "Pescadero Lunch Ride", distance: 105000, elevationGain: 1800 },
-  { id: 55556, name: "Quick Conservatory Loop", distance: 45000, elevationGain: 900 },
+  { id: 55555, name: "Mt Tam Loop", distance: 65000, elevationGain: 1200 },
+  { id: 55556, name: "Headlands Out and Back", distance: 42000, elevationGain: 750 },
 ];
 
 function createInput(area: GeographicBounds): HistoryAnalysisInput {
@@ -65,31 +65,31 @@ function createInput(area: GeographicBounds): HistoryAnalysisInput {
 
 describe("analyzeHistory", () => {
   test("filters activities within the bounding box", () => {
-    const result = analyzeHistory(createInput(paloAltoArea));
+    const result = analyzeHistory(createInput(marinArea));
     expect(result.relevantActivities).toHaveLength(2);
     expect(result.relevantActivities.map((a) => a.id)).toEqual([12345, 12346]);
   });
 
   test("returns no relevant activities for an area with no rides", () => {
-    const result = analyzeHistory(createInput(sacramentoArea));
+    const result = analyzeHistory(createInput(santaCruzArea));
     expect(result.relevantActivities).toHaveLength(0);
   });
 
   test("passes all segments through as reusable", () => {
-    const result = analyzeHistory(createInput(paloAltoArea));
+    const result = analyzeHistory(createInput(marinArea));
     expect(result.reusableSegments).toEqual(segments);
   });
 
   test("describes familiar roads from matching activities", () => {
-    const result = analyzeHistory(createInput(paloAltoArea));
+    const result = analyzeHistory(createInput(marinArea));
     expect(result.familiarRoads).toHaveLength(2);
-    expect(result.familiarRoads[0]).toContain("Pescadero Loop via Tunitas Creek");
-    expect(result.familiarRoads[0]).toContain("105.0km");
-    expect(result.familiarRoads[0]).toContain("1800m gain");
+    expect(result.familiarRoads[0]).toContain("Mt Tam via Panoramic Highway");
+    expect(result.familiarRoads[0]).toContain("65.0km");
+    expect(result.familiarRoads[0]).toContain("1200m gain");
   });
 
   test("reports new territory when no activities match", () => {
-    const result = analyzeHistory(createInput(sacramentoArea));
+    const result = analyzeHistory(createInput(santaCruzArea));
     expect(result.familiarRoads).toHaveLength(0);
     expect(result.newOpportunities).toHaveLength(1);
     expect(result.newOpportunities[0]).toContain("new territory");
@@ -98,7 +98,7 @@ describe("analyzeHistory", () => {
   test("reports few rides when under threshold", () => {
     const singleActivity: ActivitySummary[] = [activities[0]];
     const result = analyzeHistory({
-      area: paloAltoArea,
+      area: marinArea,
       activities: singleActivity,
       segments,
       routes,
@@ -110,10 +110,10 @@ describe("analyzeHistory", () => {
   test("reports no new opportunities when area is well-covered", () => {
     const manyActivities: ActivitySummary[] = [
       ...activities,
-      { ...activities[0], id: 12347, name: "Morning Ride" },
+      { ...activities[0], id: 12347, name: "Camino Alto to Paradise Loop" },
     ];
     const result = analyzeHistory({
-      area: paloAltoArea,
+      area: marinArea,
       activities: manyActivities,
       segments,
       routes,
@@ -122,21 +122,21 @@ describe("analyzeHistory", () => {
   });
 
   test("computes preferences from all activities", () => {
-    const result = analyzeHistory(createInput(paloAltoArea));
-    expect(result.preferences.avgDistance).toBe(75000);
-    expect(result.preferences.avgElevation).toBe(1350);
-    expect(result.preferences.avgDuration).toBe(10800);
+    const result = analyzeHistory(createInput(marinArea));
+    expect(result.preferences.avgDistance).toBe(53500);
+    expect(result.preferences.avgElevation).toBe(975);
+    expect(result.preferences.avgDuration).toBe(9000);
   });
 
   test("computes preferences even when no activities match the area", () => {
-    const result = analyzeHistory(createInput(sacramentoArea));
-    expect(result.preferences.avgDistance).toBe(75000);
-    expect(result.preferences.avgElevation).toBe(1350);
+    const result = analyzeHistory(createInput(santaCruzArea));
+    expect(result.preferences.avgDistance).toBe(53500);
+    expect(result.preferences.avgElevation).toBe(975);
   });
 
   test("handles empty activities", () => {
     const result = analyzeHistory({
-      area: paloAltoArea,
+      area: marinArea,
       activities: [],
       segments: [],
       routes: [],
@@ -153,14 +153,14 @@ describe("analyzeHistory", () => {
 
 describe("buildHistoryPrompt", () => {
   test("includes familiarity context for new territory", () => {
-    const output = analyzeHistory(createInput(sacramentoArea));
+    const output = analyzeHistory(createInput(santaCruzArea));
     const prompt = buildHistoryPrompt(output);
     expect(prompt).toContain("No prior rides");
   });
 
   test("includes familiarity context for few rides", () => {
     const output = analyzeHistory({
-      area: paloAltoArea,
+      area: marinArea,
       activities: [activities[0]],
       segments,
       routes,
@@ -171,8 +171,11 @@ describe("buildHistoryPrompt", () => {
 
   test("omits familiarity context for well-covered area", () => {
     const output = analyzeHistory({
-      area: paloAltoArea,
-      activities: [...activities, { ...activities[0], id: 12347, name: "Morning Ride" }],
+      area: marinArea,
+      activities: [
+        ...activities,
+        { ...activities[0], id: 12347, name: "Camino Alto to Paradise Loop" },
+      ],
       segments,
       routes,
     });
@@ -181,14 +184,14 @@ describe("buildHistoryPrompt", () => {
   });
 
   test("includes segment context when segments exist", () => {
-    const output = analyzeHistory(createInput(paloAltoArea));
+    const output = analyzeHistory(createInput(marinArea));
     const prompt = buildHistoryPrompt(output);
     expect(prompt).toContain("2 known segments");
   });
 
   test("omits segment context when no segments", () => {
     const output = analyzeHistory({
-      area: paloAltoArea,
+      area: marinArea,
       activities,
       segments: [],
       routes,

--- a/src/skills/history-analysis/history-analysis.test.ts
+++ b/src/skills/history-analysis/history-analysis.test.ts
@@ -5,6 +5,7 @@ import type {
   ActivitySummary,
   GeographicBounds,
   HistoryAnalysisInput,
+  RidingPreferences,
   SegmentSummary,
 } from "./types";
 
@@ -35,6 +36,22 @@ const activities: ActivitySummary[] = [
     movingTime: 7200,
     startLatLng: [37.8577, -122.4853],
   },
+  {
+    id: 12347,
+    name: "Camino Alto to Paradise Loop",
+    distance: 55000,
+    elevationGain: 600,
+    movingTime: 9000,
+    startLatLng: [37.906, -122.5474],
+  },
+  {
+    id: 12348,
+    name: "Bolinas Ridge Epic",
+    distance: 110000,
+    elevationGain: 2200,
+    movingTime: 18000,
+    startLatLng: [37.906, -122.5474],
+  },
 ];
 
 const segments: SegmentSummary[] = [
@@ -59,15 +76,22 @@ const routes = [
   { id: 55556, name: "Headlands Out and Back", distance: 42000, elevationGain: 750 },
 ];
 
+const preferences: RidingPreferences = {
+  rideCount: 150,
+  distance: { avg: 54000, max: 110000 },
+  elevation: { avg: 850, max: 2200 },
+  duration: { avg: 9000, max: 18000 },
+};
+
 function createInput(area: GeographicBounds): HistoryAnalysisInput {
-  return { area, activities, segments, routes };
+  return { area, activities, segments, routes, preferences };
 }
 
 describe("analyzeHistory", () => {
   test("filters activities within the bounding box", () => {
     const result = analyzeHistory(createInput(marinArea));
-    expect(result.relevantActivities).toHaveLength(2);
-    expect(result.relevantActivities.map((a) => a.id)).toEqual([12345, 12346]);
+    expect(result.relevantActivities).toHaveLength(4);
+    expect(result.relevantActivities.map((a) => a.id)).toEqual([12345, 12346, 12347, 12348]);
   });
 
   test("returns no relevant activities for an area with no rides", () => {
@@ -80,74 +104,28 @@ describe("analyzeHistory", () => {
     expect(result.reusableSegments).toEqual(segments);
   });
 
-  test("describes familiar roads from matching activities", () => {
+  test("passes preferences through from input", () => {
     const result = analyzeHistory(createInput(marinArea));
-    expect(result.familiarRoads).toHaveLength(2);
-    expect(result.familiarRoads[0]).toContain("Mt Tam via Panoramic Highway");
-    expect(result.familiarRoads[0]).toContain("65.0km");
-    expect(result.familiarRoads[0]).toContain("1200m gain");
-  });
-
-  test("reports new territory when no activities match", () => {
-    const result = analyzeHistory(createInput(santaCruzArea));
-    expect(result.familiarRoads).toHaveLength(0);
-    expect(result.newOpportunities).toHaveLength(1);
-    expect(result.newOpportunities[0]).toContain("new territory");
-  });
-
-  test("reports few rides when under threshold", () => {
-    const singleActivity: ActivitySummary[] = [activities[0]];
-    const result = analyzeHistory({
-      area: marinArea,
-      activities: singleActivity,
-      segments,
-      routes,
-    });
-    expect(result.newOpportunities).toHaveLength(1);
-    expect(result.newOpportunities[0]).toContain("Few rides");
-  });
-
-  test("reports no new opportunities when area is well-covered", () => {
-    const manyActivities: ActivitySummary[] = [
-      ...activities,
-      { ...activities[0], id: 12347, name: "Camino Alto to Paradise Loop" },
-    ];
-    const result = analyzeHistory({
-      area: marinArea,
-      activities: manyActivities,
-      segments,
-      routes,
-    });
-    expect(result.newOpportunities).toHaveLength(0);
-  });
-
-  test("computes preferences from all activities", () => {
-    const result = analyzeHistory(createInput(marinArea));
-    expect(result.preferences.avgDistance).toBe(53500);
-    expect(result.preferences.avgElevation).toBe(975);
-    expect(result.preferences.avgDuration).toBe(9000);
-  });
-
-  test("computes preferences even when no activities match the area", () => {
-    const result = analyzeHistory(createInput(santaCruzArea));
-    expect(result.preferences.avgDistance).toBe(53500);
-    expect(result.preferences.avgElevation).toBe(975);
+    expect(result.preferences).toEqual(preferences);
   });
 
   test("handles empty activities", () => {
+    const emptyPreferences: RidingPreferences = {
+      rideCount: 0,
+      distance: { avg: 0, max: 0 },
+      elevation: { avg: 0, max: 0 },
+      duration: { avg: 0, max: 0 },
+    };
     const result = analyzeHistory({
       area: marinArea,
       activities: [],
       segments: [],
       routes: [],
+      preferences: emptyPreferences,
     });
     expect(result.relevantActivities).toHaveLength(0);
     expect(result.reusableSegments).toHaveLength(0);
-    expect(result.familiarRoads).toHaveLength(0);
-    expect(result.newOpportunities).toHaveLength(1);
-    expect(result.preferences.avgDistance).toBe(0);
-    expect(result.preferences.avgElevation).toBe(0);
-    expect(result.preferences.avgDuration).toBe(0);
+    expect(result.preferences).toEqual(emptyPreferences);
   });
 });
 
@@ -164,21 +142,14 @@ describe("buildHistoryPrompt", () => {
       activities: [activities[0]],
       segments,
       routes,
+      preferences,
     });
     const prompt = buildHistoryPrompt(output);
     expect(prompt).toContain("Few prior rides");
   });
 
   test("omits familiarity context for well-covered area", () => {
-    const output = analyzeHistory({
-      area: marinArea,
-      activities: [
-        ...activities,
-        { ...activities[0], id: 12347, name: "Camino Alto to Paradise Loop" },
-      ],
-      segments,
-      routes,
-    });
+    const output = analyzeHistory(createInput(marinArea));
     const prompt = buildHistoryPrompt(output);
     expect(prompt).not.toContain("prior rides");
   });
@@ -195,6 +166,7 @@ describe("buildHistoryPrompt", () => {
       activities,
       segments: [],
       routes,
+      preferences,
     });
     const prompt = buildHistoryPrompt(output);
     expect(prompt).not.toContain("segments");

--- a/src/skills/history-analysis/index.ts
+++ b/src/skills/history-analysis/index.ts
@@ -1,5 +1,5 @@
 export { analyzeHistory } from "./analyze";
-export { historyAnalysisPrompt } from "./prompt";
+export { buildHistoryPrompt } from "./prompt";
 export type {
   ActivitySummary,
   GeographicBounds,

--- a/src/skills/history-analysis/index.ts
+++ b/src/skills/history-analysis/index.ts
@@ -1,0 +1,11 @@
+export { analyzeHistory } from "./analyze";
+export { historyAnalysisPrompt } from "./prompt";
+export type {
+  ActivitySummary,
+  GeographicBounds,
+  HistoryAnalysisInput,
+  HistoryAnalysisOutput,
+  RidingPreferences,
+  RouteSummary,
+  SegmentSummary,
+} from "./types";

--- a/src/skills/history-analysis/index.ts
+++ b/src/skills/history-analysis/index.ts
@@ -5,6 +5,7 @@ export type {
   GeographicBounds,
   HistoryAnalysisInput,
   HistoryAnalysisOutput,
+  MetricSummary,
   RidingPreferences,
   RouteSummary,
   SegmentSummary,

--- a/src/skills/history-analysis/prompt.ts
+++ b/src/skills/history-analysis/prompt.ts
@@ -1,35 +1,26 @@
-export const historyAnalysisPrompt = `You are analyzing a cyclist's ride history to inform route planning.
+import type { HistoryAnalysisOutput } from "./types";
 
-## How Cyclists Use Past Rides
+const corePrompt = `Analyze this cyclist's ride history to inform route planning. Use familiar roads as reliable building blocks and flag new territory as exploration opportunities.`;
 
-Experienced cyclists build mental maps of roads they've ridden. When planning a new route, they draw on:
+function familiarityContext(output: HistoryAnalysisOutput): string {
+  if (output.relevantActivities.length === 0) {
+    return "No prior rides in this area — all roads are new. Prioritize well-known routes and flag uncertainty about conditions.";
+  }
+  if (output.relevantActivities.length < 3) {
+    return "Few prior rides in this area. Mix familiar roads with new ones for a balanced route.";
+  }
+  return "";
+}
 
-- **Familiar segments**: Roads they know well — surface quality, traffic patterns, good shoulders, scenic sections. These are reliable building blocks for new routes.
-- **Known climbs**: Climbs they've done before have known effort levels. A rider who has done Tunitas Creek knows exactly what to expect and can plan energy accordingly.
-- **Preferred corridors**: Patterns emerge — a rider who consistently rides west toward the coast values ocean views and quiet roads over the fastest path.
+function segmentsContext(output: HistoryAnalysisOutput): string {
+  if (output.reusableSegments.length === 0) return "";
+  return `${output.reusableSegments.length} known segments available — prefer incorporating these as they mark interesting road sections with benchmark data.`;
+}
 
-## Familiar vs. New Territory
+export function buildHistoryPrompt(output: HistoryAnalysisOutput): string {
+  const sections = [corePrompt, familiarityContext(output), segmentsContext(output)].filter(
+    Boolean,
+  );
 
-- **Familiar territory**: Roads ridden multiple times. The rider knows conditions, hazards, and effort required. These are safe choices for route building.
-- **New territory**: Areas with few or no past rides. These represent exploration opportunities but carry uncertainty about road quality, traffic, and difficulty.
-- A good route often mixes both: familiar roads for reliability, new roads for discovery.
-
-## Inferring Riding Preferences
-
-Preferences emerge from patterns across all rides, not just rides in the target area:
-
-- **Distance**: Average ride length indicates comfort zone. A rider averaging 80km rides differently than one averaging 40km.
-- **Elevation**: Average elevation gain reveals climbing appetite. High averages suggest the rider seeks out hills.
-- **Duration**: Average moving time shows how long the rider typically spends on the bike.
-
-These preferences help calibrate route suggestions — don't suggest a 150km mountainous route to someone who typically rides 50km on flat terrain.
-
-## Segments as Building Blocks
-
-Strava segments mark notable road sections — usually climbs, sprints, or scenic stretches. Segments the rider has completed before are valuable because:
-
-- The rider has benchmark times to compare against
-- They know the effort required
-- Segments often mark the most interesting parts of a road
-
-All segments in the target area are candidates for inclusion in a new route, whether the rider has done them before or not.`;
+  return sections.join("\n\n");
+}

--- a/src/skills/history-analysis/prompt.ts
+++ b/src/skills/history-analysis/prompt.ts
@@ -1,0 +1,35 @@
+export const historyAnalysisPrompt = `You are analyzing a cyclist's ride history to inform route planning.
+
+## How Cyclists Use Past Rides
+
+Experienced cyclists build mental maps of roads they've ridden. When planning a new route, they draw on:
+
+- **Familiar segments**: Roads they know well — surface quality, traffic patterns, good shoulders, scenic sections. These are reliable building blocks for new routes.
+- **Known climbs**: Climbs they've done before have known effort levels. A rider who has done Tunitas Creek knows exactly what to expect and can plan energy accordingly.
+- **Preferred corridors**: Patterns emerge — a rider who consistently rides west toward the coast values ocean views and quiet roads over the fastest path.
+
+## Familiar vs. New Territory
+
+- **Familiar territory**: Roads ridden multiple times. The rider knows conditions, hazards, and effort required. These are safe choices for route building.
+- **New territory**: Areas with few or no past rides. These represent exploration opportunities but carry uncertainty about road quality, traffic, and difficulty.
+- A good route often mixes both: familiar roads for reliability, new roads for discovery.
+
+## Inferring Riding Preferences
+
+Preferences emerge from patterns across all rides, not just rides in the target area:
+
+- **Distance**: Average ride length indicates comfort zone. A rider averaging 80km rides differently than one averaging 40km.
+- **Elevation**: Average elevation gain reveals climbing appetite. High averages suggest the rider seeks out hills.
+- **Duration**: Average moving time shows how long the rider typically spends on the bike.
+
+These preferences help calibrate route suggestions — don't suggest a 150km mountainous route to someone who typically rides 50km on flat terrain.
+
+## Segments as Building Blocks
+
+Strava segments mark notable road sections — usually climbs, sprints, or scenic stretches. Segments the rider has completed before are valuable because:
+
+- The rider has benchmark times to compare against
+- They know the effort required
+- Segments often mark the most interesting parts of a road
+
+All segments in the target area are candidates for inclusion in a new route, whether the rider has done them before or not.`;

--- a/src/skills/history-analysis/types.ts
+++ b/src/skills/history-analysis/types.ts
@@ -1,0 +1,49 @@
+export interface GeographicBounds {
+  sw: { lat: number; lng: number };
+  ne: { lat: number; lng: number };
+}
+
+export interface ActivitySummary {
+  id: number;
+  name: string;
+  distance: number;
+  elevationGain: number;
+  movingTime: number;
+  startLatLng: [number, number];
+}
+
+export interface SegmentSummary {
+  id: number;
+  name: string;
+  distance: number;
+  avgGrade: number;
+  elevDifference: number;
+}
+
+export interface RouteSummary {
+  id: number;
+  name: string;
+  distance: number;
+  elevationGain: number;
+}
+
+export interface HistoryAnalysisInput {
+  area: GeographicBounds;
+  activities: ActivitySummary[];
+  segments: SegmentSummary[];
+  routes: RouteSummary[];
+}
+
+export interface RidingPreferences {
+  avgDistance: number;
+  avgElevation: number;
+  avgDuration: number;
+}
+
+export interface HistoryAnalysisOutput {
+  relevantActivities: ActivitySummary[];
+  reusableSegments: SegmentSummary[];
+  familiarRoads: string[];
+  newOpportunities: string[];
+  preferences: RidingPreferences;
+}

--- a/src/skills/history-analysis/types.ts
+++ b/src/skills/history-analysis/types.ts
@@ -27,23 +27,28 @@ export interface RouteSummary {
   elevationGain: number;
 }
 
+export interface MetricSummary {
+  avg: number;
+  max: number;
+}
+
+export interface RidingPreferences {
+  rideCount: number;
+  distance: MetricSummary;
+  elevation: MetricSummary;
+  duration: MetricSummary;
+}
+
 export interface HistoryAnalysisInput {
   area: GeographicBounds;
   activities: ActivitySummary[];
   segments: SegmentSummary[];
   routes: RouteSummary[];
-}
-
-export interface RidingPreferences {
-  avgDistance: number;
-  avgElevation: number;
-  avgDuration: number;
+  preferences: RidingPreferences;
 }
 
 export interface HistoryAnalysisOutput {
   relevantActivities: ActivitySummary[];
   reusableSegments: SegmentSummary[];
-  familiarRoads: string[];
-  newOpportunities: string[];
   preferences: RidingPreferences;
 }


### PR DESCRIPTION
Closes #7

First skill implementation for the route agent. Analyzes a cyclist's Strava ride history against a target geographic area to identify familiar territory, reusable segments, and rider capability — providing context that informs downstream route planning.

## Changes

- Adds `analyzeHistory` to filter activities by bounding box and pass through rider preferences and segments
- Rider preferences (`RidingPreferences`) are accepted as input rather than computed from individual activities, matching the shape of Strava's `GET /athletes/{id}/stats` endpoint — avg and max for distance, elevation, and duration, plus ride count as a volume indicator
- Adds `buildHistoryPrompt` to dynamically construct the agent prompt based on analysis output, progressively disclosing familiarity and segment context only when relevant
- Exports types (`GeographicBounds`, `ActivitySummary`, `MetricSummary`, `RidingPreferences`, etc.) for use by the orchestrator

## Testing

- Unit tests cover geographic filtering, segment pass-through, preference pass-through, and empty input
- Promptfoo evals validate prompt quality across three scenarios: new territory (Santa Cruz), familiar area (Marin with segments), and partial coverage (Mill Valley bike path)
