### PR TITLE
Add GPX generation from GraphHopper routes

### DIFF
--- a/src/gpx/__snapshots__/gpx.test.ts.snap
+++ b/src/gpx/__snapshots__/gpx.test.ts.snap
@@ -1,0 +1,32 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`generateGpx snapshot 1`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="route-agent"
+  xmlns="http://www.topografix.com/GPX/1/1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+  <metadata>
+    <name>Skyline Boulevard</name>
+    <desc>Palo Alto to Half Moon Bay</desc>
+  </metadata>
+  <trk>
+    <name>Skyline Boulevard</name>
+    <trkseg>
+      <trkpt lat="37.4419" lon="-122.143">
+        <ele>10</ele>
+        <time>2026-03-15T08:00:00.000Z</time>
+      </trkpt>
+      <trkpt lat="37.41" lon="-122.2">
+        <ele>45</ele>
+        <time>2026-03-15T08:18:28.376Z</time>
+      </trkpt>
+      <trkpt lat="37.32" lon="-122.35">
+        <ele>180</ele>
+        <time>2026-03-15T09:08:18.128Z</time>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>
+"
+`;

--- a/src/gpx/generate.ts
+++ b/src/gpx/generate.ts
@@ -1,0 +1,100 @@
+import type { RoutePath } from "../graphhopper/server";
+
+export interface GpxOptions {
+  name?: string;
+  description?: string;
+  startTime?: Date;
+}
+
+function escapeXml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function estimateTimestamps(path: RoutePath, startTime: Date): Date[] {
+  const coords = path.points.coordinates;
+  if (coords.length === 0) return [];
+
+  const totalDistance = path.distance;
+  const totalTime = path.time;
+
+  const timestamps: Date[] = [startTime];
+  let cumulativeDistance = 0;
+
+  for (let i = 1; i < coords.length; i++) {
+    const prev = coords[i - 1];
+    const curr = coords[i];
+    const segmentDistance = haversine(prev[1], prev[0], curr[1], curr[0]);
+    cumulativeDistance += segmentDistance;
+
+    const fraction = totalDistance > 0 ? cumulativeDistance / totalDistance : i / coords.length;
+    const elapsed = fraction * totalTime;
+    timestamps.push(new Date(startTime.getTime() + elapsed));
+  }
+
+  return timestamps;
+}
+
+function haversine(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const R = 6371000;
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+export function generateGpx(path: RoutePath, options: GpxOptions = {}): string {
+  const { name = "Route", description, startTime } = options;
+  const coords = path.points.coordinates;
+
+  const timestamps = startTime ? estimateTimestamps(path, startTime) : null;
+
+  const metadataLines = ["  <metadata>", `    <name>${escapeXml(name)}</name>`];
+  if (description) {
+    metadataLines.push(`    <desc>${escapeXml(description)}</desc>`);
+  }
+  metadataLines.push("  </metadata>");
+
+  const trackpoints = coords.map((coord, i) => {
+    const [lng, lat, ele] = coord;
+    const attrs = `lat="${lat}" lon="${lng}"`;
+    const children: string[] = [];
+    if (ele !== undefined) {
+      children.push(`        <ele>${ele}</ele>`);
+    }
+    if (timestamps?.[i]) {
+      children.push(`        <time>${timestamps[i].toISOString()}</time>`);
+    }
+
+    if (children.length === 0) {
+      return `      <trkpt ${attrs} />`;
+    }
+
+    return [`      <trkpt ${attrs}>`, ...children, "      </trkpt>"].join("\n");
+  });
+
+  const lines = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<gpx version="1.1" creator="route-agent"',
+    '  xmlns="http://www.topografix.com/GPX/1/1"',
+    '  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"',
+    '  xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">',
+    ...metadataLines,
+    "  <trk>",
+    `    <name>${escapeXml(name)}</name>`,
+    "    <trkseg>",
+    ...trackpoints,
+    "    </trkseg>",
+    "  </trk>",
+    "</gpx>",
+  ];
+
+  return `${lines.join("\n")}\n`;
+}

--- a/src/gpx/gpx.test.ts
+++ b/src/gpx/gpx.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test";
+import type { RoutePath } from "../graphhopper/server";
+import { generateGpx } from "./generate";
+
+function createRoutePath(overrides: Partial<RoutePath> = {}): RoutePath {
+  return {
+    distance: 5000,
+    time: 900000,
+    points: {
+      coordinates: [
+        [-122.143, 37.4419, 10],
+        [-122.2, 37.41, 45],
+        [-122.35, 37.32, 180],
+      ],
+    },
+    instructions: [
+      { text: "Head southwest", distance: 2000, time: 360000 },
+      { text: "Turn right", distance: 3000, time: 540000 },
+    ],
+    ...overrides,
+  };
+}
+
+describe("generateGpx", () => {
+  test("produces valid GPX 1.1 with required attributes", () => {
+    const gpx = generateGpx(createRoutePath());
+
+    expect(gpx).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(gpx).toContain('version="1.1"');
+    expect(gpx).toContain('xmlns="http://www.topografix.com/GPX/1/1"');
+    expect(gpx).toContain("xsi:schemaLocation");
+    expect(gpx).toContain('creator="route-agent"');
+  });
+
+  test("includes track points with lat, lon, and elevation", () => {
+    const gpx = generateGpx(createRoutePath());
+
+    expect(gpx).toContain('lat="37.4419" lon="-122.143"');
+    expect(gpx).toContain("<ele>10</ele>");
+    expect(gpx).toContain('lat="37.41" lon="-122.2"');
+    expect(gpx).toContain("<ele>45</ele>");
+    expect(gpx).toContain('lat="37.32" lon="-122.35"');
+    expect(gpx).toContain("<ele>180</ele>");
+  });
+
+  test("uses default name when none provided", () => {
+    const gpx = generateGpx(createRoutePath());
+
+    expect(gpx).toContain("<name>Route</name>");
+  });
+
+  test("uses custom name and description", () => {
+    const gpx = generateGpx(createRoutePath(), {
+      name: "Tunitas Creek Loop",
+      description: "A scenic ride over the coastal hills",
+    });
+
+    expect(gpx).toContain("<name>Tunitas Creek Loop</name>");
+    expect(gpx).toContain("<desc>A scenic ride over the coastal hills</desc>");
+  });
+
+  test("escapes XML special characters in name and description", () => {
+    const gpx = generateGpx(createRoutePath(), {
+      name: 'Route with "quotes" & <angles>',
+      description: "Tom's route",
+    });
+
+    expect(gpx).toContain("<name>Route with &quot;quotes&quot; &amp; &lt;angles&gt;</name>");
+    expect(gpx).toContain("<desc>Tom&apos;s route</desc>");
+  });
+
+  test("includes timestamps when startTime is provided", () => {
+    const startTime = new Date("2026-03-15T08:00:00Z");
+    const gpx = generateGpx(createRoutePath(), { startTime });
+
+    expect(gpx).toContain("<time>2026-03-15T08:00:00.000Z</time>");
+    const timeMatches = gpx.match(/<time>/g);
+    expect(timeMatches).toHaveLength(3);
+  });
+
+  test("omits timestamps when startTime is not provided", () => {
+    const gpx = generateGpx(createRoutePath());
+
+    expect(gpx).not.toContain("<time>");
+  });
+
+  test("timestamps progress monotonically", () => {
+    const startTime = new Date("2026-03-15T08:00:00Z");
+    const gpx = generateGpx(createRoutePath(), { startTime });
+
+    const times = [...gpx.matchAll(/<time>([^<]+)<\/time>/g)].map((m) => new Date(m[1]).getTime());
+
+    for (let i = 1; i < times.length; i++) {
+      expect(times[i]).toBeGreaterThan(times[i - 1]);
+    }
+  });
+
+  test("handles coordinates without elevation", () => {
+    const path = createRoutePath({
+      points: {
+        coordinates: [
+          [-122.143, 37.4419],
+          [-122.2, 37.41],
+        ],
+      },
+    });
+
+    const gpx = generateGpx(path);
+
+    expect(gpx).toContain('lat="37.4419" lon="-122.143"');
+    expect(gpx).not.toContain("<ele>");
+  });
+
+  test("handles empty coordinates", () => {
+    const path = createRoutePath({
+      points: { coordinates: [] },
+    });
+
+    const gpx = generateGpx(path);
+
+    expect(gpx).toContain("<trkseg>");
+    expect(gpx).toContain("</trkseg>");
+    expect(gpx).not.toContain("<trkpt");
+  });
+
+  test("ends with a newline", () => {
+    const gpx = generateGpx(createRoutePath());
+    expect(gpx.endsWith("\n")).toBe(true);
+  });
+
+  test("snapshot", () => {
+    const gpx = generateGpx(createRoutePath(), {
+      name: "Skyline Boulevard",
+      description: "Palo Alto to Half Moon Bay",
+      startTime: new Date("2026-03-15T08:00:00Z"),
+    });
+
+    expect(gpx).toMatchSnapshot();
+  });
+});

--- a/src/gpx/index.ts
+++ b/src/gpx/index.ts
@@ -1,0 +1,1 @@
+export { type GpxOptions, generateGpx } from "./generate";


### PR DESCRIPTION
Adds a `src/gpx/` module that converts GraphHopper `RoutePath` responses into valid GPX 1.1 XML. The output includes track points with latitude, longitude, and elevation, plus optional route metadata and estimated timestamps.

## Issue

Closes #9

## Changes

- `src/gpx/generate.ts`: Core `generateGpx` function that accepts a `RoutePath` and optional `GpxOptions` (name, description, start time). Produces GPX 1.1 with proper namespace declarations and schema location for compatibility with Strava, Wahoo, and other platforms.
- `src/gpx/index.ts`: Public exports.
- `src/gpx/gpx.test.ts`: 12 tests covering GPX structure, elevation, timestamps, XML escaping, edge cases (empty coordinates, missing elevation), and a snapshot test.

## Testing

All 12 tests pass. Typecheck and Biome lint are clean.
