### PR TITLE
Add custom eval scorers

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -90,6 +90,47 @@ tests:
   - file://cases/generic-items.yaml
 ```
 
+## Custom Scorers
+
+Reusable scoring functions in `scorers/` for domain-specific eval assertions. Reference them from any colocated `promptfooconfig.yaml` using the `file://` prefix with a named export:
+
+```yaml
+assert:
+  - type: javascript
+    value: file://../../evals/scorers/nutrition.ts:calorieEstimate
+    config:
+      min: 200
+      max: 300
+```
+
+The path is relative to the config file's location. Adjust the `../` depth to match.
+
+### Available Scorers
+
+**JSON** (`scorers/json.ts`)
+- `hasKeys` — assert required keys exist in JSON output
+- `numericRanges` — assert numeric fields fall within expected ranges
+
+**Nutrition** (`scorers/nutrition.ts`)
+- `completeNutrition` — validate all nutrition fields are present
+- `calorieEstimate` — partial-credit scoring for calorie accuracy
+- `macroConsistency` — check that macro grams are consistent with calorie count
+- `confidenceLevel` — assert `confidence` matches expected value (`"exact"` or `"estimated"`)
+
+**Route** (`scorers/route.ts`)
+- `mentionsLocations` — assert output references specific geographic locations
+- `invokesSkills` — assert output references expected skill names
+- `distanceInRange` — validate route distance against a target with tolerance
+
+**Cycling** (`scorers/cycling.ts`)
+- `foodStopSpacing` — validate food stops are spaced within safe intervals
+- `clothingForConditions` — assert clothing recommendations match temperature range
+- `climbAwareness` — validate effort management and sequencing for climbs
+
+### Scorer Return Values
+
+Each scorer returns a `GradingResult` with `pass`, `score` (0-1), and `reason`. Many scorers award partial credit rather than binary pass/fail.
+
 ## Gold Standard Cases
 
 Real trip examples used as regression fixtures. These are blocked on user input — see [#26](https://github.com/bendrucker/route-agent/issues/26).

--- a/evals/scorers/cycling.ts
+++ b/evals/scorers/cycling.ts
@@ -1,0 +1,225 @@
+import type { GradingResult } from "./types";
+
+/**
+ * Assert that food stops are spaced at reasonable intervals for cycling.
+ *
+ * Extracts mile/km markers from the output and checks that the gaps between
+ * consecutive stops don't exceed `maxGapMi` (default 30 miles). On long rides,
+ * gaps over 30 miles without food risk bonking.
+ *
+ * Usage in promptfooconfig.yaml:
+ * ```yaml
+ * assert:
+ *   - type: javascript
+ *     value: file://../../evals/scorers/cycling.ts:foodStopSpacing
+ *     config:
+ *       maxGapMi: 30
+ *       totalDistanceMi: 90
+ * ```
+ */
+export function foodStopSpacing(
+  output: unknown,
+  context: { config?: { maxGapMi?: number; totalDistanceMi?: number } },
+): GradingResult {
+  const maxGapMi = context.config?.maxGapMi ?? 30;
+  const totalMi = context.config?.totalDistanceMi;
+
+  if (!totalMi) {
+    return { pass: false, score: 0, reason: "Config must specify totalDistanceMi" };
+  }
+
+  const text = String(output);
+
+  const miPattern = /(?:mile|mi)\s*(\d+(?:\.\d+)?)|(\d+(?:\.\d+)?)\s*(?:mile|mi)/gi;
+  const markers: number[] = [];
+  for (const match of text.matchAll(miPattern)) {
+    markers.push(Number.parseFloat(match[1] ?? match[2]));
+  }
+
+  if (markers.length === 0) {
+    const hasFoodMention = /\b(?:food|cafe|restaurant|stop|eat|lunch|snack|bakery)\b/i.test(text);
+    if (totalMi <= maxGapMi) {
+      return {
+        pass: true,
+        score: 1,
+        reason: `Route is ${totalMi} mi — no food stops needed within ${maxGapMi} mi threshold`,
+      };
+    }
+    return {
+      pass: hasFoodMention,
+      score: hasFoodMention ? 0.5 : 0,
+      reason: hasFoodMention
+        ? "Food stops mentioned but no mile markers found to verify spacing"
+        : `No food stops found for a ${totalMi} mi route`,
+    };
+  }
+
+  markers.sort((a, b) => a - b);
+  const points = [0, ...markers, totalMi];
+  const gaps: number[] = [];
+  for (let i = 1; i < points.length; i++) {
+    gaps.push(points[i] - points[i - 1]);
+  }
+
+  const maxActualGap = Math.max(...gaps);
+  if (maxActualGap <= maxGapMi) {
+    return {
+      pass: true,
+      score: 1,
+      reason: `Max gap between stops is ${Math.round(maxActualGap)} mi (limit: ${maxGapMi} mi)`,
+    };
+  }
+
+  return {
+    pass: false,
+    score: Math.max(0, 1 - (maxActualGap - maxGapMi) / maxGapMi),
+    reason: `Max gap between stops is ${Math.round(maxActualGap)} mi, exceeds ${maxGapMi} mi limit`,
+  };
+}
+
+/**
+ * Assert that clothing recommendations are appropriate for temperature conditions.
+ *
+ * Checks that the output mentions gear appropriate for the given temperature range.
+ * For example, arm warmers should be mentioned when temps are 50-65F, and a
+ * vest/jacket when there's a large temperature swing.
+ *
+ * Usage in promptfooconfig.yaml:
+ * ```yaml
+ * assert:
+ *   - type: javascript
+ *     value: file://../../evals/scorers/cycling.ts:clothingForConditions
+ *     config:
+ *       lowTempF: 45
+ *       highTempF: 72
+ * ```
+ */
+export function clothingForConditions(
+  output: unknown,
+  context: { config?: { lowTempF?: number; highTempF?: number } },
+): GradingResult {
+  const { lowTempF, highTempF } = context.config ?? {};
+  if (lowTempF === undefined || highTempF === undefined) {
+    return { pass: false, score: 0, reason: "Config must specify lowTempF and highTempF" };
+  }
+
+  const text = String(output).toLowerCase();
+  const checks: { condition: string; pass: boolean }[] = [];
+
+  if (lowTempF < 50) {
+    const hasColdGear =
+      /\b(?:jacket|thermal|long.?sleeve|winter|warm|insulated|shoe.?cover|toe.?cover|heavy|fleece)\b/.test(
+        text,
+      );
+    checks.push({ condition: `Cold gear for ${lowTempF}F`, pass: hasColdGear });
+  }
+
+  if (lowTempF >= 50 && lowTempF < 65) {
+    const hasLightWarmth =
+      /\b(?:arm.?warmer|knee.?warmer|leg.?warmer|vest|gilet|light.?layer|base.?layer)\b/.test(text);
+    checks.push({ condition: `Light warmth layers for ${lowTempF}F`, pass: hasLightWarmth });
+  }
+
+  const swing = highTempF - lowTempF;
+  if (swing > 15) {
+    const hasLayering = /\b(?:layer|remov|shed|pocket|storage|bag|transition|peel|strip)\b/.test(
+      text,
+    );
+    checks.push({ condition: `Layering strategy for ${swing}F swing`, pass: hasLayering });
+  }
+
+  if (swing > 20) {
+    const hasStorage = /\b(?:pocket|bag|saddle.?bag|storage|stash|pack)\b/.test(text);
+    checks.push({ condition: `Storage for removed layers (${swing}F swing)`, pass: hasStorage });
+  }
+
+  if (checks.length === 0) {
+    return {
+      pass: true,
+      score: 1,
+      reason: `Conditions (${lowTempF}-${highTempF}F) don't trigger specific gear checks`,
+    };
+  }
+
+  const passed = checks.filter((c) => c.pass);
+  const failed = checks.filter((c) => !c.pass);
+  const score = passed.length / checks.length;
+
+  if (failed.length === 0) {
+    return { pass: true, score: 1, reason: "All clothing checks passed" };
+  }
+
+  return {
+    pass: false,
+    score,
+    reason: `Failed: ${failed.map((c) => c.condition).join("; ")}`,
+  };
+}
+
+/**
+ * Assert that the output demonstrates awareness of climb sequencing concerns.
+ *
+ * For routes with significant climbing, the response should address effort
+ * management, sequencing rationale, or recovery between climbs.
+ *
+ * Usage in promptfooconfig.yaml:
+ * ```yaml
+ * assert:
+ *   - type: javascript
+ *     value: file://../../evals/scorers/cycling.ts:climbAwareness
+ *     config:
+ *       elevationGainFt: 4000
+ *       climbCount: 2
+ * ```
+ */
+export function climbAwareness(
+  output: unknown,
+  context: { config?: { elevationGainFt?: number; climbCount?: number } },
+): GradingResult {
+  const { elevationGainFt = 0, climbCount = 1 } = context.config ?? {};
+
+  if (elevationGainFt < 2000 && climbCount < 2) {
+    return { pass: true, score: 1, reason: "Minimal climbing — no sequencing concerns" };
+  }
+
+  const text = String(output).toLowerCase();
+  const checks: { condition: string; pass: boolean }[] = [];
+
+  const mentionsClimbing =
+    /\b(?:climb|ascent|elevation|gradient|grade|steep|hill|summit|peak|col)\b/.test(text);
+  checks.push({ condition: "Mentions climbing", pass: mentionsClimbing });
+
+  if (elevationGainFt >= 3000) {
+    const mentionsEffort =
+      /\b(?:effort|energy|pace|conserve|manage|fatigue|fresh|legs|recover|stamina)\b/.test(text);
+    checks.push({
+      condition: `Effort management for ${elevationGainFt}ft gain`,
+      pass: mentionsEffort,
+    });
+  }
+
+  if (climbCount >= 2) {
+    const mentionsSequencing =
+      /\b(?:first|second|order|sequence|before|after|then|save|harder|easier|warm.?up)\b/.test(
+        text,
+      );
+    checks.push({
+      condition: `Sequencing for ${climbCount} climbs`,
+      pass: mentionsSequencing,
+    });
+  }
+
+  const passed = checks.filter((c) => c.pass);
+  const failed = checks.filter((c) => !c.pass);
+  const score = passed.length / checks.length;
+
+  if (failed.length === 0) {
+    return { pass: true, score: 1, reason: "All climb awareness checks passed" };
+  }
+
+  return {
+    pass: false,
+    score,
+    reason: `Failed: ${failed.map((c) => c.condition).join("; ")}`,
+  };
+}

--- a/evals/scorers/index.ts
+++ b/evals/scorers/index.ts
@@ -1,0 +1,11 @@
+export { climbAwareness, clothingForConditions, foodStopSpacing } from "./cycling";
+
+export { extractJson, hasKeys, numericRanges } from "./json";
+export {
+  calorieEstimate,
+  completeNutrition,
+  confidenceLevel,
+  macroConsistency,
+} from "./nutrition";
+export { distanceInRange, invokesSkills, mentionsLocations } from "./route";
+export type { AssertionContext, AssertionFn, GradingResult } from "./types";

--- a/evals/scorers/json.ts
+++ b/evals/scorers/json.ts
@@ -1,0 +1,122 @@
+import type { GradingResult } from "./types";
+
+/**
+ * Extract and parse JSON from LLM output.
+ *
+ * Handles both raw JSON strings and JSON embedded in markdown code fences.
+ * Promptfoo auto-parses pure JSON output, so `output` may already be an object.
+ */
+export function extractJson(output: unknown): { value: unknown; error?: string } {
+  if (typeof output === "object" && output !== null) {
+    return { value: output };
+  }
+
+  const text = String(output);
+  const fenced = text.match(/```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/);
+  const candidate = fenced ? fenced[1] : text;
+
+  try {
+    return { value: JSON.parse(candidate) };
+  } catch {
+    return { value: null, error: "Output does not contain valid JSON" };
+  }
+}
+
+/**
+ * Assert that the output contains valid JSON with all required keys.
+ *
+ * Usage in promptfooconfig.yaml:
+ * ```yaml
+ * assert:
+ *   - type: javascript
+ *     value: file://../../evals/scorers/json.ts:hasKeys
+ *     config:
+ *       keys: ["calories", "carbs_g", "protein_g"]
+ * ```
+ */
+export function hasKeys(output: unknown, context: { config?: { keys?: string[] } }): GradingResult {
+  const keys = context.config?.keys ?? [];
+  if (keys.length === 0) {
+    return { pass: false, score: 0, reason: "No keys specified in config" };
+  }
+
+  const { value, error } = extractJson(output);
+  if (error) {
+    return { pass: false, score: 0, reason: error };
+  }
+
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return { pass: false, score: 0, reason: "Output is not a JSON object" };
+  }
+
+  const record = value as Record<string, unknown>;
+  const missing = keys.filter((k) => !(k in record));
+
+  if (missing.length > 0) {
+    return {
+      pass: false,
+      score: (keys.length - missing.length) / keys.length,
+      reason: `Missing keys: ${missing.join(", ")}`,
+    };
+  }
+
+  return { pass: true, score: 1, reason: "All required keys present" };
+}
+
+/**
+ * Assert that numeric fields in the JSON output fall within expected ranges.
+ *
+ * Usage in promptfooconfig.yaml:
+ * ```yaml
+ * assert:
+ *   - type: javascript
+ *     value: file://../../evals/scorers/json.ts:numericRanges
+ *     config:
+ *       ranges:
+ *         calories: { min: 200, max: 300 }
+ *         protein_g: { min: 5 }
+ * ```
+ */
+export function numericRanges(
+  output: unknown,
+  context: { config?: { ranges?: Record<string, { min?: number; max?: number }> } },
+): GradingResult {
+  const ranges = context.config?.ranges ?? {};
+  const fields = Object.keys(ranges);
+  if (fields.length === 0) {
+    return { pass: false, score: 0, reason: "No ranges specified in config" };
+  }
+
+  const { value, error } = extractJson(output);
+  if (error) {
+    return { pass: false, score: 0, reason: error };
+  }
+
+  const record = value as Record<string, unknown>;
+  const failures: string[] = [];
+
+  for (const field of fields) {
+    const actual = record[field];
+    if (typeof actual !== "number") {
+      failures.push(`${field}: not a number (got ${typeof actual})`);
+      continue;
+    }
+    const { min, max } = ranges[field];
+    if (min !== undefined && actual < min) {
+      failures.push(`${field}: ${actual} < min ${min}`);
+    }
+    if (max !== undefined && actual > max) {
+      failures.push(`${field}: ${actual} > max ${max}`);
+    }
+  }
+
+  if (failures.length > 0) {
+    return {
+      pass: false,
+      score: (fields.length - failures.length) / fields.length,
+      reason: failures.join("; "),
+    };
+  }
+
+  return { pass: true, score: 1, reason: "All numeric fields within expected ranges" };
+}

--- a/evals/scorers/nutrition.ts
+++ b/evals/scorers/nutrition.ts
@@ -1,0 +1,194 @@
+import { extractJson } from "./json";
+import type { GradingResult } from "./types";
+
+interface NutritionOutput {
+  calories?: number;
+  carbs_g?: number;
+  protein_g?: number;
+  fat_g?: number;
+  serving_size?: string;
+  confidence?: string;
+}
+
+const REQUIRED_FIELDS: (keyof NutritionOutput)[] = [
+  "calories",
+  "carbs_g",
+  "protein_g",
+  "fat_g",
+  "serving_size",
+  "confidence",
+];
+
+/**
+ * Validate that the output contains a complete nutrition facts response
+ * with all required fields.
+ *
+ * Usage in promptfooconfig.yaml:
+ * ```yaml
+ * assert:
+ *   - type: javascript
+ *     value: file://../../evals/scorers/nutrition.ts:completeNutrition
+ * ```
+ */
+export function completeNutrition(output: unknown): GradingResult {
+  const { value, error } = extractJson(output);
+  if (error) {
+    return { pass: false, score: 0, reason: error };
+  }
+
+  const data = value as Record<string, unknown>;
+  const missing = REQUIRED_FIELDS.filter((f) => !(f in data));
+
+  if (missing.length > 0) {
+    return {
+      pass: false,
+      score: (REQUIRED_FIELDS.length - missing.length) / REQUIRED_FIELDS.length,
+      reason: `Missing nutrition fields: ${missing.join(", ")}`,
+    };
+  }
+
+  return { pass: true, score: 1, reason: "All nutrition fields present" };
+}
+
+/**
+ * Validate calorie estimate with partial credit for close values.
+ *
+ * Returns full credit when within range, partial credit that degrades
+ * linearly up to `tolerance` calories away (default 100).
+ *
+ * Usage in promptfooconfig.yaml:
+ * ```yaml
+ * assert:
+ *   - type: javascript
+ *     value: file://../../evals/scorers/nutrition.ts:calorieEstimate
+ *     config:
+ *       min: 200
+ *       max: 300
+ *       tolerance: 100
+ * ```
+ */
+export function calorieEstimate(
+  output: unknown,
+  context: { config?: { min?: number; max?: number; tolerance?: number } },
+): GradingResult {
+  const { min, max, tolerance = 100 } = context.config ?? {};
+  if (min === undefined || max === undefined) {
+    return { pass: false, score: 0, reason: "Config must specify min and max calories" };
+  }
+
+  const { value, error } = extractJson(output);
+  if (error) {
+    return { pass: false, score: 0, reason: error };
+  }
+
+  const data = value as NutritionOutput;
+  if (typeof data.calories !== "number") {
+    return { pass: false, score: 0, reason: "calories field is not a number" };
+  }
+
+  if (data.calories >= min && data.calories <= max) {
+    return { pass: true, score: 1, reason: `Calories ${data.calories} within [${min}, ${max}]` };
+  }
+
+  const distance = Math.min(Math.abs(data.calories - min), Math.abs(data.calories - max));
+  const score = Math.max(0, 1 - distance / tolerance);
+
+  return {
+    pass: false,
+    score,
+    reason: `Calories ${data.calories} outside [${min}, ${max}] (distance: ${distance})`,
+  };
+}
+
+/**
+ * Assert that macronutrient grams are self-consistent with calorie count.
+ *
+ * Computes calories from macros using standard conversion factors
+ * (carbs: 4 cal/g, protein: 4 cal/g, fat: 9 cal/g) and checks that
+ * the sum is within a tolerance of the reported calorie value.
+ *
+ * Usage in promptfooconfig.yaml:
+ * ```yaml
+ * assert:
+ *   - type: javascript
+ *     value: file://../../evals/scorers/nutrition.ts:macroConsistency
+ *     config:
+ *       tolerance: 0.2
+ * ```
+ */
+export function macroConsistency(
+  output: unknown,
+  context: { config?: { tolerance?: number } },
+): GradingResult {
+  const tolerance = context.config?.tolerance ?? 0.2;
+
+  const { value, error } = extractJson(output);
+  if (error) {
+    return { pass: false, score: 0, reason: error };
+  }
+
+  const data = value as NutritionOutput;
+  if (
+    typeof data.calories !== "number" ||
+    typeof data.carbs_g !== "number" ||
+    typeof data.protein_g !== "number" ||
+    typeof data.fat_g !== "number"
+  ) {
+    return { pass: false, score: 0, reason: "Missing or non-numeric macro fields" };
+  }
+
+  const computed = data.carbs_g * 4 + data.protein_g * 4 + data.fat_g * 9;
+  const ratio = Math.abs(computed - data.calories) / data.calories;
+
+  if (ratio <= tolerance) {
+    return {
+      pass: true,
+      score: 1,
+      reason: `Macro-derived calories (${Math.round(computed)}) within ${tolerance * 100}% of reported (${data.calories})`,
+    };
+  }
+
+  return {
+    pass: false,
+    score: Math.max(0, 1 - ratio),
+    reason: `Macro-derived calories (${Math.round(computed)}) differ from reported (${data.calories}) by ${Math.round(ratio * 100)}%`,
+  };
+}
+
+/**
+ * Assert that the confidence field matches an expected value.
+ *
+ * Usage in promptfooconfig.yaml:
+ * ```yaml
+ * assert:
+ *   - type: javascript
+ *     value: file://../../evals/scorers/nutrition.ts:confidenceLevel
+ *     config:
+ *       expected: "exact"
+ * ```
+ */
+export function confidenceLevel(
+  output: unknown,
+  context: { config?: { expected?: string } },
+): GradingResult {
+  const expected = context.config?.expected;
+  if (!expected) {
+    return { pass: false, score: 0, reason: "Config must specify expected confidence level" };
+  }
+
+  const { value, error } = extractJson(output);
+  if (error) {
+    return { pass: false, score: 0, reason: error };
+  }
+
+  const data = value as NutritionOutput;
+  if (data.confidence === expected) {
+    return { pass: true, score: 1, reason: `Confidence is "${expected}"` };
+  }
+
+  return {
+    pass: false,
+    score: 0,
+    reason: `Expected confidence "${expected}", got "${data.confidence}"`,
+  };
+}

--- a/evals/scorers/route.ts
+++ b/evals/scorers/route.ts
@@ -1,0 +1,167 @@
+import type { GradingResult } from "./types";
+
+/**
+ * Assert that the output mentions specific geographic locations.
+ *
+ * Performs case-insensitive substring matching. Partial credit is awarded
+ * proportional to the number of locations found.
+ *
+ * Usage in promptfooconfig.yaml:
+ * ```yaml
+ * assert:
+ *   - type: javascript
+ *     value: file://../../evals/scorers/route.ts:mentionsLocations
+ *     config:
+ *       locations: ["Hawk Hill", "Panoramic Highway", "Stinson Beach"]
+ * ```
+ */
+export function mentionsLocations(
+  output: unknown,
+  context: { config?: { locations?: string[] } },
+): GradingResult {
+  const locations = context.config?.locations ?? [];
+  if (locations.length === 0) {
+    return { pass: false, score: 0, reason: "No locations specified in config" };
+  }
+
+  const text = String(output).toLowerCase();
+  const found: string[] = [];
+  const missing: string[] = [];
+
+  for (const loc of locations) {
+    if (text.includes(loc.toLowerCase())) {
+      found.push(loc);
+    } else {
+      missing.push(loc);
+    }
+  }
+
+  const score = found.length / locations.length;
+
+  if (missing.length === 0) {
+    return { pass: true, score: 1, reason: "All locations mentioned" };
+  }
+
+  return {
+    pass: false,
+    score,
+    reason: `Missing locations: ${missing.join(", ")}`,
+  };
+}
+
+/**
+ * Assert that the output references expected skills being invoked.
+ *
+ * Checks for skill names (case-insensitive) in the output text. Useful
+ * for end-to-end evals that verify the orchestrator selected the right skills.
+ *
+ * Usage in promptfooconfig.yaml:
+ * ```yaml
+ * assert:
+ *   - type: javascript
+ *     value: file://../../evals/scorers/route.ts:invokesSkills
+ *     config:
+ *       skills: ["History Analysis", "Climb Planning", "Food Stop Planning"]
+ * ```
+ */
+export function invokesSkills(
+  output: unknown,
+  context: { config?: { skills?: string[] } },
+): GradingResult {
+  const skills = context.config?.skills ?? [];
+  if (skills.length === 0) {
+    return { pass: false, score: 0, reason: "No skills specified in config" };
+  }
+
+  const text = String(output).toLowerCase();
+  const found: string[] = [];
+  const missing: string[] = [];
+
+  for (const skill of skills) {
+    if (text.includes(skill.toLowerCase())) {
+      found.push(skill);
+    } else {
+      missing.push(skill);
+    }
+  }
+
+  const score = found.length / skills.length;
+
+  if (missing.length === 0) {
+    return { pass: true, score: 1, reason: "All expected skills referenced" };
+  }
+
+  return {
+    pass: false,
+    score,
+    reason: `Missing skill references: ${missing.join(", ")}`,
+  };
+}
+
+/**
+ * Validate distance values in the output against a target with tolerance.
+ *
+ * Searches for distance-like patterns (e.g., "65 km", "40 miles", "90mi")
+ * and checks that at least one falls within the expected range.
+ *
+ * Usage in promptfooconfig.yaml:
+ * ```yaml
+ * assert:
+ *   - type: javascript
+ *     value: file://../../evals/scorers/route.ts:distanceInRange
+ *     config:
+ *       target_mi: 90
+ *       tolerance: 0.15
+ * ```
+ */
+export function distanceInRange(
+  output: unknown,
+  context: { config?: { target_mi?: number; target_km?: number; tolerance?: number } },
+): GradingResult {
+  const { target_mi, target_km, tolerance = 0.15 } = context.config ?? {};
+
+  if (target_mi === undefined && target_km === undefined) {
+    return { pass: false, score: 0, reason: "Config must specify target_mi or target_km" };
+  }
+
+  const targetKm = target_km ?? (target_mi ?? 0) * 1.60934;
+  const text = String(output);
+
+  const miPattern = /(\d+(?:\.\d+)?)\s*(?:miles?|mi)\b/gi;
+  const kmPattern = /(\d+(?:\.\d+)?)\s*(?:kilometers?|kilometres?|km)\b/gi;
+
+  const distances: number[] = [];
+  for (const match of text.matchAll(miPattern)) {
+    distances.push(Number.parseFloat(match[1]) * 1.60934);
+  }
+  for (const match of text.matchAll(kmPattern)) {
+    distances.push(Number.parseFloat(match[1]));
+  }
+
+  if (distances.length === 0) {
+    return { pass: false, score: 0, reason: "No distance values found in output" };
+  }
+
+  const minKm = targetKm * (1 - tolerance);
+  const maxKm = targetKm * (1 + tolerance);
+  const inRange = distances.find((d) => d >= minKm && d <= maxKm);
+
+  if (inRange) {
+    return {
+      pass: true,
+      score: 1,
+      reason: `Found distance ${Math.round(inRange)} km within ${tolerance * 100}% of target ${Math.round(targetKm)} km`,
+    };
+  }
+
+  const closest = distances.reduce((a, b) =>
+    Math.abs(a - targetKm) < Math.abs(b - targetKm) ? a : b,
+  );
+  const ratio = Math.abs(closest - targetKm) / targetKm;
+
+  return {
+    pass: false,
+    score: Math.max(0, 1 - ratio),
+    reason: `Closest distance ${Math.round(closest)} km is ${Math.round(ratio * 100)}% off target ${Math.round(targetKm)} km`,
+  };
+}

--- a/evals/scorers/types.ts
+++ b/evals/scorers/types.ts
@@ -1,0 +1,27 @@
+/**
+ * Promptfoo grading result returned by custom scorer functions.
+ *
+ * @see https://www.promptfoo.dev/docs/configuration/expected-outputs/javascript/
+ */
+export interface GradingResult {
+  pass: boolean;
+  score: number;
+  reason: string;
+}
+
+/**
+ * Context object provided by Promptfoo to assertion functions.
+ */
+export interface AssertionContext {
+  prompt: string;
+  vars: Record<string, string>;
+  test: Record<string, unknown>;
+  config?: Record<string, unknown>;
+}
+
+/**
+ * A Promptfoo assertion function that evaluates LLM output.
+ *
+ * When `output` is valid JSON, Promptfoo auto-parses it before passing to the function.
+ */
+export type AssertionFn = (output: unknown, context: AssertionContext) => GradingResult;

--- a/evals/tsconfig.json
+++ b/evals/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "../dist/evals",
+    "noEmit": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["results"]
+}


### PR DESCRIPTION
Custom scorer utilities in `evals/scorers/` for domain-specific eval assertions, reusable across colocated Promptfoo configs via `file://` references with named exports.

## Changes

Four scorer modules organized by domain concern:

- **`json.ts`** — generic JSON validation (`hasKeys`, `numericRanges`)
- **`nutrition.ts`** — nutrition facts validation with partial credit (`calorieEstimate`, `macroConsistency`, `confidenceLevel`, `completeNutrition`)
- **`route.ts`** — route output validation (`mentionsLocations`, `invokesSkills`, `distanceInRange`)
- **`cycling.ts`** — cycling domain checks (`foodStopSpacing`, `clothingForConditions`, `climbAwareness`)

All scorers return `GradingResult` with `pass`, `score` (0-1), and `reason`. Most award partial credit rather than binary pass/fail.

Added `evals/tsconfig.json` extending the root config so scorers are type-checked independently from `src/`.

Closes #28
