### PR TITLE
Fix eval model ids and align tooling with Bun

### DIFF
--- a/.claude/skills/promptfoo/SKILL.md
+++ b/.claude/skills/promptfoo/SKILL.md
@@ -4,8 +4,8 @@ description: |
   Promptfoo evaluation framework for testing and comparing LLM outputs.
   Use when writing eval configs, creating test cases, debugging eval runs, or working with assertions.
 allowed-tools:
-  - Bash(npx promptfoo:*)
-  - Bash(npm run evals:*)
+  - Bash(bunx promptfoo:*)
+  - Bash(bun run evals:*)
   - WebFetch(domain:www.promptfoo.dev)
 ---
 
@@ -139,11 +139,11 @@ Each case file contains a YAML array of test objects.
 ## CLI
 
 ```bash
-npx promptfoo eval                         # Run with auto-discovered config
-npx promptfoo eval -c path/to/config.yaml  # Specific config
-npx promptfoo eval --filter-metadata key=v # Filter tests
-npx promptfoo view                         # Web UI for results
-npx promptfoo cache clear                  # Clear result cache
+bunx promptfoo eval                         # Run with auto-discovered config
+bunx promptfoo eval -c path/to/config.yaml  # Specific config
+bunx promptfoo eval --filter-metadata key=v # Filter tests
+bunx promptfoo view                         # Web UI for results
+bunx promptfoo cache clear                  # Clear result cache
 ```
 
 ## References

--- a/docs/evals.md
+++ b/docs/evals.md
@@ -65,7 +65,7 @@ prompts:
   - file://../../prompt.txt
 
 providers:
-  - anthropic:messages:claude-sonnet-4-5-20250929
+  - anthropic:messages:claude-sonnet-5
 
 tests:
   # Commercial products - exact values
@@ -100,7 +100,7 @@ prompts:
   - file://../../prompt.txt
 
 providers:
-  - anthropic:messages:claude-sonnet-4-5-20250929
+  - anthropic:messages:claude-sonnet-5
 
 tests:
   - vars:
@@ -140,7 +140,7 @@ prompts:
   - file://../../prompt.txt
 
 providers:
-  - anthropic:messages:claude-sonnet-4-5-20250929
+  - anthropic:messages:claude-sonnet-5
 
 tests:
   # Gold standard case from user

--- a/evals/README.md
+++ b/evals/README.md
@@ -64,7 +64,7 @@ prompts:
   - file://../../prompt.txt
 
 providers:
-  - anthropic:messages:claude-sonnet-4-5-20250929
+  - anthropic:messages:claude-sonnet-5
 
 defaultTest:
   options:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:fix": "bunx @biomejs/biome check --write .",
     "typecheck": "tsc --noEmit",
     "evals": "bun evals/run-all.ts",
-    "evals:view": "promptfoo view"
+    "evals:view": "bunx promptfoo view"
   },
   "keywords": [
     "cycling",

--- a/src/skills/history-analysis/evals/promptfooconfig.yaml
+++ b/src/skills/history-analysis/evals/promptfooconfig.yaml
@@ -5,13 +5,13 @@ prompts:
   - file://prompt.txt
 
 providers:
-  - id: anthropic:messages:claude-sonnet-4-6
+  - id: anthropic:messages:claude-sonnet-5
     config:
       temperature: 0.0
       max_tokens: 1024
 
 defaultTest:
   options:
-    provider: anthropic:messages:claude-sonnet-4-6
+    provider: anthropic:messages:claude-sonnet-5
 
 tests: file://cases/scenarios.yaml


### PR DESCRIPTION
Fixes tooling drift left behind after the npm-to-Bun migration in #37.

The eval configs and docs referenced Sonnet model ids that no longer resolve. The history-analysis eval config pinned `claude-sonnet-4-6`, and the promptfoo docs pinned the dated `claude-sonnet-4-5-20250929`. Both now use the current `claude-sonnet-5` alias.

The promptfoo skill and one package script still assumed npm. The skill's `allowed-tools` and CLI examples used `npx`/`npm run`, and the `evals:view` script called a bare `promptfoo`. These now use `bunx`/`bun run` to match the rest of the repo.

No behavior changes beyond the model ids and command runners. Verified against install, lint, typecheck, and the test suite; the osm tests that need a live API key remain gated behind `LIVE_API`.
