### PR TITLE
Add implemented-vs-planned status markers to docs

### DIFF
--- a/.claude/skills/project/SKILL.md
+++ b/.claude/skills/project/SKILL.md
@@ -13,6 +13,10 @@ allowed-tools:
 
 Assess project status, find ready tasks, and orchestrate parallel work.
 
+## Merge Convention
+
+PRs merge via squash. Commit subjects on `main` read `Title (#NN)`, where `NN` is the PR number.
+
 ## Commands
 
 | Command | Action |
@@ -70,10 +74,12 @@ Issue: <title>
 
 ## Milestone Priority
 
-1. Foundation
-2. Eval Setup (parallel)
-3. Strava Integration
-4. GraphHopper Integration
+Complete: Foundation, Eval Setup, Strava Integration, GraphHopper Integration. Verify against `gh api repos/bendrucker/route-agent/milestones` before relying on this list.
+
+1. Foundation ✅
+2. Eval Setup (parallel) ✅
+3. Strava Integration ✅
+4. GraphHopper Integration ✅
 5. Route Synthesis
 6. Place Search, Water Stops, Climb Integration, Weather Integration
 7. Ride Preparation, Narrative Research

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -4,6 +4,10 @@ Sub-agents are focused, stateless helpers that skills invoke for specific data r
 
 See [architecture.md](architecture.md#skills-vs-sub-agents) for when to use skills vs sub-agents.
 
+## Implementation Status
+
+No sub-agents are implemented yet. The Nutrition Facts Agent below is a design spec on the roadmap.
+
 ## Skills vs Sub-agents
 
 | Characteristic | Skill | Sub-agent |

--- a/docs/evals.md
+++ b/docs/evals.md
@@ -2,6 +2,10 @@
 
 Test-driven development for the route agent using structured evaluations.
 
+## Implementation Status
+
+The colocated layout below is the target. Today one component ships a config: `src/skills/history-analysis/evals/promptfooconfig.yaml`. Shared scorers exist in `evals/scorers/` (`json`, `nutrition`, `route`, `cycling`). The `src/agents/`, other `src/skills/*/`, and `src/orchestrator/` eval directories shown in examples do not exist yet.
+
 ## Framework Choice: Promptfoo
 
 [Promptfoo](https://github.com/promptfoo/promptfoo) is a TypeScript-native evaluation framework that fits our needs:

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -4,6 +4,25 @@ Skills are composable research patterns that use [tools](tools.md) to accomplish
 
 See [architecture.md](architecture.md) for orchestration model and design decisions.
 
+## Implementation Status {#implementation-status}
+
+Only History Analysis has code today. The rest are design specs on the roadmap.
+
+| Skill | Status | Location |
+|-------|--------|----------|
+| History Analysis | ✅ Implemented | `src/skills/history-analysis/` |
+| Route Optimization | 🔜 Planned | - |
+| Climb Planning | 🔜 Planned | - |
+| Weather Planning | 🔜 Planned | - |
+| Food Stop Planning | 🔜 Planned | - |
+| Water Stop Planning | 🔜 Planned | - |
+| Narrative Research | 🔜 Planned | - |
+| Safety Assessment | 🔜 Planned | - |
+| Nutrition Planning | 🔜 Planned | - |
+| Clothing Planning | 🔜 Planned | - |
+
+Route Optimization depends on the GraphHopper tool, which exists in `src/graphhopper/`. The skill that drives it does not exist yet.
+
 ## Skill Architecture {#skill-architecture}
 
 ```mermaid

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -2,6 +2,25 @@
 
 Tools abstract access to external data sources. Each tool provides a consistent interface to an API or data service.
 
+## Implementation Status
+
+Three data sources have code today. The rest are design specs on the roadmap.
+
+| Tool | Status | Location |
+|------|--------|----------|
+| 1. Activity History (Strava) | ✅ Implemented | `src/strava/` |
+| 2. Routing Engine (GraphHopper) | ✅ Implemented | `src/graphhopper/` |
+| 3. Place Search (Google Maps) | 🔜 Planned | - |
+| 4. Climb Data (PJAMM) | 🔜 Planned | - |
+| 5. Weather (WeatherKit) | 🔜 Planned | - |
+| 6. Water & Infrastructure (OSM) | ✅ Implemented | `src/osm/` |
+| 7. Elevation | 🔜 Planned | - |
+| 8. Street Imagery | 🔜 Deferred | - |
+| 9. Road Surface | 🔜 Deferred | - |
+| 10. Traffic & Safety | 🔜 Deferred | - |
+
+GPX output, the final route format, is implemented in `src/gpx/`. It is not a data source, so it has no section below.
+
 ## Tool Categories
 
 ```mermaid

--- a/evals/README.md
+++ b/evals/README.md
@@ -2,6 +2,10 @@
 
 Promptfoo-based evaluations colocated with the code they test.
 
+## Implementation Status
+
+One component ships a colocated config today: `src/skills/history-analysis/evals/promptfooconfig.yaml`. The scorers in `scorers/` all exist (`json`, `nutrition`, `route`, `cycling`). The `src/agents/nutrition-facts/` and `src/skills/clothing-planning/` trees in the examples below are illustrative and do not exist yet.
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
The design docs describe the full 10-skill, 10-tool system, but most of it has no code yet. An agent reading them builds a false map of the repo and assumes components exist that do not. This is a light-touch fix: keep the design content as the roadmap it is, and add status markers so a reader can tell what ships today from what is still planned.

Each doc gets a compact status table (or a short note) near the top. The tables cross-reference the `src/` path for every implemented component, verified against the tree on `main`: `src/strava/`, `src/graphhopper/`, and `src/osm/` for tools, and `src/skills/history-analysis/` as the one skill with code. Everything else is marked planned or deferred. No design content was rewritten or removed.

## Changes

- `docs/skills.md`, `docs/agents.md`, `docs/tools.md`: status tables covering the skills, sub-agents, and data-source tools, with `src/` paths for the implemented ones. Notes call out that Route Optimization has a working GraphHopper tool but no skill driving it, and that GPX output ships in `src/gpx/` even though it is not a data source.
- `docs/evals.md`, `evals/README.md`: notes clarifying that only `src/skills/history-analysis/evals/` ships a colocated config, that the scorers in `evals/scorers/` (`json`, `nutrition`, `route`, `cycling`) exist, and that the `agents/`, `skills/*/`, and `orchestrator/` eval trees in the examples do not exist yet.
- `.claude/skills/project/SKILL.md`: mark the completed milestones (Foundation, Eval Setup, Strava Integration, GraphHopper Integration, the last of which completed when #9 merged), point readers at `gh api .../milestones` for ground truth, and document that the repo squash-merges with `Title (#NN)` subjects.

## Testing

The diff is documentation and skill markdown with no runtime surface. `bun run lint` and `bun run typecheck` were run to confirm the change leaves the build untouched.
