### PR TITLE
Fix lint and doc paper cuts from tooling migration

### DIFF
--- a/.claude/skills/promptfoo/SKILL.md
+++ b/.claude/skills/promptfoo/SKILL.md
@@ -31,7 +31,7 @@ prompts:
     Inline prompt with {{variable}} substitution
 
 providers:
-  - anthropic:messages:claude-sonnet-4-5-20250929
+  - anthropic:messages:claude-sonnet-5
 
 defaultTest:
   options:
@@ -62,9 +62,9 @@ evaluateOptions:
 
 | Model | ID |
 |-------|----|
-| Opus 4.5 | `anthropic:messages:claude-opus-4-5-20251101` |
-| Sonnet 4.5 | `anthropic:messages:claude-sonnet-4-5-20250929` |
-| Haiku 4.5 | `anthropic:messages:claude-haiku-4-5-20251001` |
+| Opus 4.8 | `anthropic:messages:claude-opus-4-8` |
+| Sonnet 5 | `anthropic:messages:claude-sonnet-5` |
+| Haiku 4.5 | `anthropic:messages:claude-haiku-4-5` |
 
 Provider config: `temperature`, `max_tokens`, `top_p`, `top_k`, `tools`, `tool_choice`
 
@@ -107,7 +107,7 @@ assert:
       - Mention at least 3 factors
       - Include specific examples
     threshold: 0.7
-    provider: anthropic:messages:claude-sonnet-4-5-20250929
+    provider: anthropic:messages:claude-sonnet-5
 ```
 
 ### javascript

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,8 +65,8 @@ When adding tests for a new HTTP client:
 Promptfoo evals are colocated with code. Load the `promptfoo` skill when writing or modifying evals.
 
 - Each component has `evals/promptfooconfig.yaml` alongside its source
-- `npm run evals` discovers and runs all colocated configs
-- `npx promptfoo eval -c <path>` runs a single config
+- `bun run evals` discovers and runs all colocated configs
+- `bunx promptfoo eval -c <path>` runs a single config
 - Gold standard fixtures live in `evals/fixtures/gold-standard/`
 - Custom scorers live in `evals/scorers/`
 - See [docs/evals.md](docs/evals.md) and [evals/README.md](evals/README.md) for details

--- a/biome.json
+++ b/biome.json
@@ -2,7 +2,7 @@
   "$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
   "plugins": ["./lint/no-import-extensions.grit"],
   "files": {
-    "includes": ["**", "!**/dist", "!**/worktrees", "!**/*.grit", "!**/fixtures"]
+    "includes": ["**", "!**/dist", "!**/worktrees", "!tmp", "!**/*.grit", "!**/fixtures"]
   },
   "formatter": {
     "indentStyle": "space",


### PR DESCRIPTION
Fixes leftovers from the Bun migration and the model id standardization in #47.

Disposable git worktrees under `tmp/` carry their own `biome.json`, which makes `bun run lint` in the main checkout fail with a nested-root-configuration error. The exclusion is root-relative (`!tmp`, not `!**/tmp`) on purpose: a `**` pattern also matches the worktree's own absolute path (`…/route-agent/tmp/<name>`), which makes Biome ignore every file when lint runs inside a worktree. The glob was exercised from both directions: `bun run lint` at the repo root with a worktree present under `tmp/`, and again from inside a `tmp/` worktree.

Also updates the promptfoo skill's example provider ids to current models (`claude-sonnet-5` to match the eval configs) and fixes `npm run evals` / `npx promptfoo` references in `CLAUDE.md` that #47 missed.
