### PR TITLE
Fix status marker inconsistencies from docs review

### DIFF
--- a/.claude/skills/project/SKILL.md
+++ b/.claude/skills/project/SKILL.md
@@ -74,7 +74,7 @@ Issue: <title>
 
 ## Milestone Priority
 
-Complete: Foundation, Eval Setup, Strava Integration, GraphHopper Integration. Verify against `gh api repos/bendrucker/route-agent/milestones` before relying on this list.
+Verify against `gh api repos/bendrucker/route-agent/milestones` before relying on this list.
 
 1. Foundation ✅
 2. Eval Setup (parallel) ✅

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -15,9 +15,9 @@ Three data sources have code today. The rest are design specs on the roadmap.
 | 5. Weather (WeatherKit) | 🔜 Planned | - |
 | 6. Water & Infrastructure (OSM) | ✅ Implemented | `src/osm/` |
 | 7. Elevation | 🔜 Planned | - |
-| 8. Street Imagery | 🔜 Deferred | - |
-| 9. Road Surface | 🔜 Deferred | - |
-| 10. Traffic & Safety | 🔜 Deferred | - |
+| 8. Street Imagery | ⏸️ Deferred | - |
+| 9. Road Surface | ⏸️ Deferred | - |
+| 10. Traffic & Safety | ⏸️ Deferred | - |
 
 GPX output, the final route format, is implemented in `src/gpx/`. It is not a data source, so it has no section below.
 


### PR DESCRIPTION
Follow-up review pass on #48. Deferred tools in `docs/tools.md` used the same 🔜 marker as Planned, contradicting their status; they now use ⏸️. The project skill's milestone section stated the completed milestones in a sentence and again as ✅ marks two lines later; the sentence now only points at the milestones API for ground truth.