### PR TITLE
Add ride reports web search skill

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -6,7 +6,7 @@ See [architecture.md](architecture.md) for orchestration model and design decisi
 
 ## Implementation Status {#implementation-status}
 
-Only History Analysis has code today. The rest are design specs on the roadmap.
+History Analysis and Narrative Research have code today. The rest are design specs on the roadmap.
 
 | Skill | Status | Location |
 |-------|--------|----------|
@@ -16,12 +16,14 @@ Only History Analysis has code today. The rest are design specs on the roadmap.
 | Weather Planning | 🔜 Planned | - |
 | Food Stop Planning | 🔜 Planned | - |
 | Water Stop Planning | 🔜 Planned | - |
-| Narrative Research | 🔜 Planned | - |
+| Narrative Research | ✅ Implemented | `src/skills/ride-reports/` |
 | Safety Assessment | 🔜 Planned | - |
 | Nutrition Planning | 🔜 Planned | - |
 | Clothing Planning | 🔜 Planned | - |
 
 Route Optimization depends on the GraphHopper tool, which exists in `src/graphhopper/`. The skill that drives it does not exist yet.
+
+Narrative Research's web search step covers ride reports and forum posts only. PJAMM narrative synthesis (step 2 of its research pattern) is not yet built.
 
 ## Skill Architecture {#skill-architecture}
 

--- a/src/skills/ride-reports/evals/cases/scenarios.yaml
+++ b/src/skills/ride-reports/evals/cases/scenarios.yaml
@@ -1,0 +1,56 @@
+- description: "Forum posts with hazards, conditions, and recommendations"
+  vars:
+    ride_reports_prompt: |-
+      Search the web for ride reports and forum posts about cycling in this area. Use your native web search to find first-hand accounts from cyclists who have ridden here.
+
+      Try queries like "Mount Diablo cycling ride report", "Mount Diablo bike route reddit", "Mount Diablo cycling club forum", and "Mount Diablo strava ride review". Check cycling forums (e.g. Reddit r/cycling, r/bicycling, local subreddits), local bike club sites, and cyclist blogs.
+
+      From each report, extract:
+      - Hazards: dangerous intersections, unmarked construction, aggressive dogs, poor pavement, high-traffic segments
+      - Conditions: current road/trail conditions, seasonal closures, surface quality
+      - Recommendations: suggested detours, best times to ride, scenic stops, parking
+
+      Attribute every finding to the source URL and title it came from. Do not invent findings that aren't grounded in a specific report.
+
+      If no relevant ride reports or forum posts turn up, say so plainly and proceed with route planning using other sources. Do not fabricate local knowledge to fill the gap.
+    search_results: |
+      Result 1: "Mt Diablo north gate descent, watch the gravel" (reddit.com/r/cycling/xyz123)
+      Posted 3 months ago: "Did the summit loop last weekend. Heads up, the descent past the north gate has a lot of loose gravel this time of year, took it slow. Otherwise road surface was great."
+
+      Result 2: "Climbing Mt Diablo: a complete guide" (example-cycling-blog.com/mt-diablo)
+      "The summit road closes to car traffic on weekend mornings until 9am, so early starts are quieter and safer for cyclists. Fill your water bottles at the ranger station near the base. There's no water past that point."
+    query: "Plan a route up Mount Diablo"
+  assert:
+    - type: llm-rubric
+      value: |
+        The response should:
+        - Flag the loose gravel on the north gate descent as a hazard, attributed to the Reddit post
+        - Note the weekend morning car closure as a condition, attributed to the cycling blog
+        - Recommend filling water at the ranger station as a recommendation, attributed to the cycling blog
+        - NOT invent hazards, conditions, or recommendations not present in the search results
+
+- description: "No relevant ride reports found: graceful degradation"
+  vars:
+    ride_reports_prompt: |-
+      Search the web for ride reports and forum posts about cycling in this area. Use your native web search to find first-hand accounts from cyclists who have ridden here.
+
+      Try queries like "Willow Creek Flats cycling ride report", "Willow Creek Flats bike route reddit", "Willow Creek Flats cycling club forum", and "Willow Creek Flats strava ride review". Check cycling forums (e.g. Reddit r/cycling, r/bicycling, local subreddits), local bike club sites, and cyclist blogs.
+
+      From each report, extract:
+      - Hazards: dangerous intersections, unmarked construction, aggressive dogs, poor pavement, high-traffic segments
+      - Conditions: current road/trail conditions, seasonal closures, surface quality
+      - Recommendations: suggested detours, best times to ride, scenic stops, parking
+
+      Attribute every finding to the source URL and title it came from. Do not invent findings that aren't grounded in a specific report.
+
+      If no relevant ride reports or forum posts turn up, say so plainly and proceed with route planning using other sources. Do not fabricate local knowledge to fill the gap.
+    search_results: |
+      No search results returned. This is a sparsely populated rural area with no indexed cycling forum posts, ride reports, or blog coverage found.
+    query: "Plan a route through Willow Creek Flats"
+  assert:
+    - type: llm-rubric
+      value: |
+        The response should:
+        - Plainly state that no relevant ride reports or forum posts were found for this area
+        - NOT fabricate hazards, conditions, or recommendations to fill the gap
+        - Suggest proceeding with route planning using other available sources

--- a/src/skills/ride-reports/evals/prompt.txt
+++ b/src/skills/ride-reports/evals/prompt.txt
@@ -1,0 +1,7 @@
+{{ride_reports_prompt}}
+
+## Web Search Results
+
+{{search_results}}
+
+Based on the web search results above, produce a summary of local knowledge for this area, organized into hazards, conditions, and recommendations. Attribute every finding to the source it came from.

--- a/src/skills/ride-reports/evals/promptfooconfig.yaml
+++ b/src/skills/ride-reports/evals/promptfooconfig.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: "Ride reports skill. Does local knowledge get extracted with attribution, and does the agent degrade gracefully when nothing relevant is found?"
+
+prompts:
+  - file://prompt.txt
+
+providers:
+  - id: anthropic:messages:claude-sonnet-5
+    config:
+      temperature: 0.0
+      max_tokens: 1024
+
+defaultTest:
+  options:
+    provider: anthropic:messages:claude-sonnet-5
+
+tests: file://cases/scenarios.yaml

--- a/src/skills/ride-reports/index.ts
+++ b/src/skills/ride-reports/index.ts
@@ -1,0 +1,8 @@
+export { organizeFindings } from "./organize";
+export { buildRideReportsPrompt } from "./prompt";
+export type {
+  LocalKnowledgeCategory,
+  LocalKnowledgeFinding,
+  RideReportsSummary,
+  Source,
+} from "./types";

--- a/src/skills/ride-reports/organize.ts
+++ b/src/skills/ride-reports/organize.ts
@@ -1,0 +1,22 @@
+import type { LocalKnowledgeFinding, RideReportsSummary } from "./types";
+
+function dedupeFindings(findings: LocalKnowledgeFinding[]): LocalKnowledgeFinding[] {
+  const seen = new Set<string>();
+  return findings.filter((finding) => {
+    const key = finding.summary.trim().toLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export function organizeFindings(findings: LocalKnowledgeFinding[]): RideReportsSummary {
+  const deduped = dedupeFindings(findings);
+
+  return {
+    hazards: deduped.filter((f) => f.category === "hazard"),
+    conditions: deduped.filter((f) => f.category === "condition"),
+    recommendations: deduped.filter((f) => f.category === "recommendation"),
+    sourceCount: new Set(deduped.map((f) => f.source.url)).size,
+  };
+}

--- a/src/skills/ride-reports/prompt.ts
+++ b/src/skills/ride-reports/prompt.ts
@@ -1,0 +1,18 @@
+const corePrompt = `Search the web for ride reports and forum posts about cycling in this area. Use your native web search to find first-hand accounts from cyclists who have ridden here.`;
+
+function searchGuidance(area: string): string {
+  return `Try queries like "${area} cycling ride report", "${area} bike route reddit", "${area} cycling club forum", and "${area} strava ride review". Check cycling forums (e.g. Reddit r/cycling, r/bicycling, local subreddits), local bike club sites, and cyclist blogs.`;
+}
+
+const extractionGuidance = `From each report, extract:
+- Hazards: dangerous intersections, unmarked construction, aggressive dogs, poor pavement, high-traffic segments
+- Conditions: current road/trail conditions, seasonal closures, surface quality
+- Recommendations: suggested detours, best times to ride, scenic stops, parking
+
+Attribute every finding to the source URL and title it came from. Do not invent findings that aren't grounded in a specific report.`;
+
+const degradationGuidance = `If no relevant ride reports or forum posts turn up, say so plainly and proceed with route planning using other sources. Do not fabricate local knowledge to fill the gap.`;
+
+export function buildRideReportsPrompt(area: string): string {
+  return [corePrompt, searchGuidance(area), extractionGuidance, degradationGuidance].join("\n\n");
+}

--- a/src/skills/ride-reports/ride-reports.test.ts
+++ b/src/skills/ride-reports/ride-reports.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import { organizeFindings } from "./organize";
+import { buildRideReportsPrompt } from "./prompt";
+import type { LocalKnowledgeFinding } from "./types";
+
+const forumSource = { url: "https://reddit.com/r/cycling/abc", title: "Mt Diablo ride report" };
+const blogSource = {
+  url: "https://example-cycling-blog.com/mt-diablo",
+  title: "Climbing Mt Diablo",
+};
+
+const findings: LocalKnowledgeFinding[] = [
+  {
+    category: "hazard",
+    summary: "Loose gravel on the descent past the north gate",
+    source: forumSource,
+  },
+  {
+    category: "hazard",
+    summary: "Loose gravel on the descent past the north gate",
+    source: blogSource,
+  },
+  {
+    category: "condition",
+    summary: "Summit road closed to cars on weekend mornings",
+    source: forumSource,
+  },
+  {
+    category: "recommendation",
+    summary: "Fill water bottles at the ranger station before the climb",
+    source: blogSource,
+  },
+];
+
+describe("organizeFindings", () => {
+  test("groups findings by category", () => {
+    const result = organizeFindings(findings);
+    expect(result.hazards).toHaveLength(1);
+    expect(result.conditions).toHaveLength(1);
+    expect(result.recommendations).toHaveLength(1);
+  });
+
+  test("dedupes findings with matching summaries, keeping the first source", () => {
+    const result = organizeFindings(findings);
+    expect(result.hazards[0]?.source).toEqual(forumSource);
+  });
+
+  test("dedupe is case-insensitive and trims whitespace", () => {
+    const result = organizeFindings([
+      { category: "hazard", summary: "  Watch for dogs near the farmhouse  ", source: forumSource },
+      { category: "hazard", summary: "watch for dogs near the farmhouse", source: blogSource },
+    ]);
+    expect(result.hazards).toHaveLength(1);
+  });
+
+  test("counts unique sources across all findings", () => {
+    const result = organizeFindings(findings);
+    expect(result.sourceCount).toBe(2);
+  });
+
+  test("handles no findings", () => {
+    const result = organizeFindings([]);
+    expect(result).toEqual({
+      hazards: [],
+      conditions: [],
+      recommendations: [],
+      sourceCount: 0,
+    });
+  });
+});
+
+describe("buildRideReportsPrompt", () => {
+  test("names the target area in the search guidance", () => {
+    const prompt = buildRideReportsPrompt("Mount Diablo");
+    expect(prompt).toContain("Mount Diablo cycling ride report");
+  });
+
+  test("directs the agent to extract hazards, conditions, and recommendations", () => {
+    const prompt = buildRideReportsPrompt("Mount Diablo");
+    expect(prompt).toContain("Hazards:");
+    expect(prompt).toContain("Conditions:");
+    expect(prompt).toContain("Recommendations:");
+  });
+
+  test("requires source attribution", () => {
+    const prompt = buildRideReportsPrompt("Mount Diablo");
+    expect(prompt).toContain("Attribute every finding");
+  });
+
+  test("includes graceful degradation guidance", () => {
+    const prompt = buildRideReportsPrompt("Mount Diablo");
+    expect(prompt).toContain("If no relevant ride reports or forum posts turn up");
+    expect(prompt).toContain("Do not fabricate");
+  });
+});

--- a/src/skills/ride-reports/types.ts
+++ b/src/skills/ride-reports/types.ts
@@ -1,0 +1,19 @@
+export type LocalKnowledgeCategory = "hazard" | "condition" | "recommendation";
+
+export interface Source {
+  url: string;
+  title: string;
+}
+
+export interface LocalKnowledgeFinding {
+  category: LocalKnowledgeCategory;
+  summary: string;
+  source: Source;
+}
+
+export interface RideReportsSummary {
+  hazards: LocalKnowledgeFinding[];
+  conditions: LocalKnowledgeFinding[];
+  recommendations: LocalKnowledgeFinding[];
+  sourceCount: number;
+}


### PR DESCRIPTION
Adds a `ride-reports` skill that finds local knowledge from forum posts and ride reports, following the pattern established by `src/skills/history-analysis/`.

There's no in-repo prior art for web search, and this skill doesn't call any search API itself. Skills are pure logic plus prompt builders: `buildRideReportsPrompt(area)` directs the consuming agent's own native web search toward ride reports and forum posts for a named area, with query phrasing, site hints (Reddit, local subreddits, bike clubs, blogs), extraction guidance (hazards, conditions, recommendations, each attributed to a source), and graceful-degradation guidance for when nothing relevant turns up. Once the agent extracts findings, `organizeFindings` deduplicates them and groups them by category while preserving source attribution.

Closes #23

## Demonstration

`buildRideReportsPrompt("Mount Diablo")` produces:

```
Search the web for ride reports and forum posts about cycling in this area. Use your native web search to find first-hand accounts from cyclists who have ridden here.

Try queries like "Mount Diablo cycling ride report", "Mount Diablo bike route reddit", "Mount Diablo cycling club forum", and "Mount Diablo strava ride review". Check cycling forums (e.g. Reddit r/cycling, r/bicycling, local subreddits), local bike club sites, and cyclist blogs.

From each report, extract:
- Hazards: dangerous intersections, unmarked construction, aggressive dogs, poor pavement, high-traffic segments
- Conditions: current road/trail conditions, seasonal closures, surface quality
- Recommendations: suggested detours, best times to ride, scenic stops, parking

Attribute every finding to the source URL and title it came from. Do not invent findings that aren't grounded in a specific report.

If no relevant ride reports or forum posts turn up, say so plainly and proceed with route planning using other sources. Do not fabricate local knowledge to fill the gap.
```

## Testing

Unit tests in `ride-reports.test.ts` cover `organizeFindings` (category grouping, dedupe by normalized summary text, unique source counting, empty input) and `buildRideReportsPrompt` (area substitution into query guidance, hazard/condition/recommendation extraction instructions, source attribution requirement, graceful-degradation wording).

The colocated eval at `src/skills/ride-reports/evals/` covers two scenarios: rich local knowledge found across multiple sources, and no relevant results found. It couldn't be run live in this environment; `bunx promptfoo eval` hits a pre-existing `zod`/`@adaline` dependency error that also reproduces against the existing `src/skills/history-analysis/evals/` config, so it's an environment issue rather than something introduced by this change.
