### PR TITLE
Add water stop planning skill

### DIFF
--- a/src/skills/water-stops/evals/cases/scenarios.yaml
+++ b/src/skills/water-stops/evals/cases/scenarios.yaml
@@ -1,0 +1,75 @@
+- description: "Remote hot-weather route with sparse coverage"
+  vars:
+    water_prompt: |-
+      Plan drinking-water refill stops along this route for hydration. Recommend fountains, water points, and stores for topping up.
+
+      Hot weather. Emphasize hydration and have riders refill at every recommended stop even if not yet thirsty.
+
+      Refill at Furnace Creek Visitor Center: 0.0 km
+      Refill at Stovepipe Wells: 40.0 km (unmarked source, verify it's flowing)
+    stop_data: |
+      {
+        "stops": [
+          { "source": { "name": "Furnace Creek Visitor Center", "type": "drinking_water" }, "distanceAlongRouteM": 0 },
+          { "source": { "name": "Stovepipe Wells", "type": "water_point" }, "distanceAlongRouteM": 40030 }
+        ],
+        "isHotWeather": true,
+        "totalDistanceM": 80060
+      }
+    query: "Plan an 80km hot-weather ride through Death Valley"
+  assert:
+    - type: llm-rubric
+      value: |
+        The response should:
+        - Reference both Furnace Creek Visitor Center and Stovepipe Wells as refill points
+        - Emphasize proactive hydration given the hot conditions
+        - Flag that Stovepipe Wells is an unmarked source that should be verified before relying on it
+
+- description: "Well-covered normal-weather route"
+  vars:
+    water_prompt: |-
+      Plan drinking-water refill stops along this route for hydration. Recommend fountains, water points, and stores for topping up.
+
+      Refill at Dolores Park Fountain: 0.0 km
+      Refill at San Rafael Fountain: 40.0 km
+      Refill at Sausalito Plaza Fountain: 80.1 km
+    stop_data: |
+      {
+        "stops": [
+          { "source": { "name": "Dolores Park Fountain", "type": "drinking_water" }, "distanceAlongRouteM": 0 },
+          { "source": { "name": "San Rafael Fountain", "type": "drinking_water" }, "distanceAlongRouteM": 40030 },
+          { "source": { "name": "Sausalito Plaza Fountain", "type": "drinking_water" }, "distanceAlongRouteM": 80060 }
+        ],
+        "isHotWeather": false,
+        "totalDistanceM": 80060
+      }
+    query: "Plan an 80km ride from San Francisco to Sausalito via San Rafael"
+  assert:
+    - type: llm-rubric
+      value: |
+        The response should:
+        - Reference all three fountains as refill points, in route order
+        - NOT suggest extra caution or emergency water carrying since conditions are normal and coverage is good
+
+- description: "No water sources in a hot, remote corridor"
+  vars:
+    water_prompt: |-
+      Plan drinking-water refill stops along this route for hydration. Recommend fountains, water points, and stores for topping up.
+
+      Hot weather. Emphasize hydration and have riders refill at every recommended stop even if not yet thirsty.
+
+      No water sources found within the route corridor over 80 km in hot conditions. Advise carrying extra water or rerouting through a town.
+    stop_data: |
+      {
+        "stops": [],
+        "isHotWeather": true,
+        "totalDistanceM": 80060
+      }
+    query: "Plan an 80km ride through a remote desert stretch in summer"
+  assert:
+    - type: llm-rubric
+      value: |
+        The response should:
+        - Clearly warn that no water sources were found on this route
+        - Advise carrying enough water for the full 80km given the hot conditions
+        - Suggest an alternative such as rerouting through a town or carrying extra capacity

--- a/src/skills/water-stops/evals/prompt.txt
+++ b/src/skills/water-stops/evals/prompt.txt
@@ -1,0 +1,13 @@
+{{water_prompt}}
+
+## Water Stop Data
+
+```json
+{{stop_data}}
+```
+
+## Route Planning Request
+
+{{query}}
+
+Based on the water stop data above, provide hydration guidance for this request. Focus on where and when the rider should refill.

--- a/src/skills/water-stops/evals/promptfooconfig.yaml
+++ b/src/skills/water-stops/evals/promptfooconfig.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: "Water stop planning skill: does the prompt produce useful hydration guidance?"
+
+prompts:
+  - file://prompt.txt
+
+providers:
+  - id: anthropic:messages:claude-sonnet-5
+    config:
+      temperature: 0.0
+      max_tokens: 1024
+
+defaultTest:
+  options:
+    provider: anthropic:messages:claude-sonnet-5
+
+tests: file://cases/scenarios.yaml

--- a/src/skills/water-stops/index.ts
+++ b/src/skills/water-stops/index.ts
@@ -1,0 +1,9 @@
+export { planWaterStops } from "./plan";
+export { buildWaterStopPrompt } from "./prompt";
+export type {
+  RoutePoint,
+  WaterSource,
+  WaterStopPlanningInput,
+  WaterStopPlanningOutput,
+  WaterStopRecommendation,
+} from "./types";

--- a/src/skills/water-stops/plan.ts
+++ b/src/skills/water-stops/plan.ts
@@ -1,0 +1,96 @@
+import type {
+  RoutePoint,
+  WaterStopPlanningInput,
+  WaterStopPlanningOutput,
+  WaterStopRecommendation,
+} from "./types";
+
+const DEFAULT_CORRIDOR_DISTANCE_M = 500;
+const DEFAULT_NORMAL_SPACING_M = 20000;
+const DEFAULT_HOT_WEATHER_SPACING_M = 10000;
+
+function haversineM(a: RoutePoint, b: RoutePoint): number {
+  const R = 6371000;
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const dLat = toRad(b.lat - a.lat);
+  const dLon = toRad(b.lon - a.lon);
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(a.lat)) * Math.cos(toRad(b.lat)) * Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(h), Math.sqrt(1 - h));
+}
+
+function cumulativeDistances(route: RoutePoint[]): number[] {
+  const distances = [0];
+  for (let i = 1; i < route.length; i++) {
+    distances.push(distances[i - 1] + haversineM(route[i - 1], route[i]));
+  }
+  return distances;
+}
+
+interface CorridorCandidate {
+  source: WaterStopPlanningInput["waterSources"][number];
+  distanceAlongRouteM: number;
+  distanceFromRouteM: number;
+}
+
+function nearestRoutePoint(
+  source: RoutePoint,
+  route: RoutePoint[],
+  distances: number[],
+): { distanceAlongRouteM: number; distanceFromRouteM: number } {
+  let nearestIndex = 0;
+  let nearestDistanceM = Number.POSITIVE_INFINITY;
+
+  for (let i = 0; i < route.length; i++) {
+    const distanceM = haversineM(source, route[i]);
+    if (distanceM < nearestDistanceM) {
+      nearestDistanceM = distanceM;
+      nearestIndex = i;
+    }
+  }
+
+  return { distanceAlongRouteM: distances[nearestIndex], distanceFromRouteM: nearestDistanceM };
+}
+
+function findCorridorCandidates(
+  input: WaterStopPlanningInput,
+  distances: number[],
+): CorridorCandidate[] {
+  const corridorDistanceM = input.corridorDistanceM ?? DEFAULT_CORRIDOR_DISTANCE_M;
+
+  return input.waterSources
+    .map((source) => ({ source, ...nearestRoutePoint(source, input.route, distances) }))
+    .filter((candidate) => candidate.distanceFromRouteM <= corridorDistanceM)
+    .sort((a, b) => a.distanceAlongRouteM - b.distanceAlongRouteM);
+}
+
+function selectSpacedStops(
+  candidates: CorridorCandidate[],
+  minSpacingM: number,
+): WaterStopRecommendation[] {
+  const stops: WaterStopRecommendation[] = [];
+  let lastStopDistanceM = Number.NEGATIVE_INFINITY;
+
+  for (const candidate of candidates) {
+    if (candidate.distanceAlongRouteM - lastStopDistanceM < minSpacingM) continue;
+    stops.push(candidate);
+    lastStopDistanceM = candidate.distanceAlongRouteM;
+  }
+
+  return stops;
+}
+
+export function planWaterStops(input: WaterStopPlanningInput): WaterStopPlanningOutput {
+  const distances = cumulativeDistances(input.route);
+  const candidates = findCorridorCandidates(input, distances);
+  const minSpacingM = input.isHotWeather
+    ? (input.hotWeatherSpacingM ?? DEFAULT_HOT_WEATHER_SPACING_M)
+    : (input.normalSpacingM ?? DEFAULT_NORMAL_SPACING_M);
+
+  return {
+    stops: selectSpacedStops(candidates, minSpacingM),
+    isHotWeather: input.isHotWeather,
+    totalDistanceM: distances[distances.length - 1] ?? 0,
+  };
+}

--- a/src/skills/water-stops/prompt.ts
+++ b/src/skills/water-stops/prompt.ts
@@ -1,0 +1,41 @@
+import type { WaterStopPlanningOutput, WaterStopRecommendation } from "./types";
+
+const corePrompt = `Plan drinking-water refill stops along this route for hydration. Recommend fountains, water points, and stores for topping up.`;
+
+function heatContext(output: WaterStopPlanningOutput): string {
+  if (!output.isHotWeather) return "";
+  return "Hot weather. Emphasize hydration and have riders refill at every recommended stop even if not yet thirsty.";
+}
+
+function coverageContext(output: WaterStopPlanningOutput): string {
+  if (output.stops.length > 0) return "";
+  const distanceKm = (output.totalDistanceM / 1000).toFixed(0);
+  return output.isHotWeather
+    ? `No water sources found within the route corridor over ${distanceKm} km in hot conditions. Advise carrying extra water or rerouting through a town.`
+    : `No water sources found within the route corridor over ${distanceKm} km. Advise carrying enough water for the full ride.`;
+}
+
+function describeStop(stop: WaterStopRecommendation): string {
+  const distanceKm = (stop.distanceAlongRouteM / 1000).toFixed(1);
+  const label =
+    stop.source.name ?? (stop.source.type === "drinking_water" ? "fountain" : "water point");
+  const reliability =
+    stop.source.type === "water_point" ? " (unmarked source, verify it's flowing)" : "";
+  return `Refill at ${label}: ${distanceKm} km${reliability}`;
+}
+
+function stopsContext(output: WaterStopPlanningOutput): string {
+  if (output.stops.length === 0) return "";
+  return output.stops.map(describeStop).join("\n");
+}
+
+export function buildWaterStopPrompt(output: WaterStopPlanningOutput): string {
+  const sections = [
+    corePrompt,
+    heatContext(output),
+    coverageContext(output),
+    stopsContext(output),
+  ].filter(Boolean);
+
+  return sections.join("\n\n");
+}

--- a/src/skills/water-stops/types.ts
+++ b/src/skills/water-stops/types.ts
@@ -1,0 +1,32 @@
+import type { WaterSource } from "../../osm/types";
+
+export interface RoutePoint {
+  lat: number;
+  lon: number;
+}
+
+export interface WaterStopPlanningInput {
+  route: RoutePoint[];
+  waterSources: WaterSource[];
+  isHotWeather: boolean;
+  /** Max distance (meters) from the route to consider a source. Default 500m. */
+  corridorDistanceM?: number;
+  /** Minimum spacing (meters) between recommended stops in normal conditions. Default 20000m. */
+  normalSpacingM?: number;
+  /** Minimum spacing (meters) between recommended stops in hot weather. Default 10000m. */
+  hotWeatherSpacingM?: number;
+}
+
+export interface WaterStopRecommendation {
+  source: WaterSource;
+  distanceAlongRouteM: number;
+  distanceFromRouteM: number;
+}
+
+export interface WaterStopPlanningOutput {
+  stops: WaterStopRecommendation[];
+  isHotWeather: boolean;
+  totalDistanceM: number;
+}
+
+export type { WaterSource } from "../../osm/types";

--- a/src/skills/water-stops/water-stops.test.ts
+++ b/src/skills/water-stops/water-stops.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import { planWaterStops } from "./plan";
+import { buildWaterStopPrompt } from "./prompt";
+import type { RoutePoint, WaterSource, WaterStopPlanningInput } from "./types";
+
+// ~10 km apart in latitude, all at the same longitude.
+const route: RoutePoint[] = [
+  { lat: 37.0, lon: -122.0 },
+  { lat: 37.09, lon: -122.0 },
+  { lat: 37.18, lon: -122.0 },
+  { lat: 37.27, lon: -122.0 },
+  { lat: 37.36, lon: -122.0 },
+];
+
+const startFountain: WaterSource = {
+  id: 1,
+  lat: 37.0,
+  lon: -122.0,
+  type: "drinking_water",
+  name: "Trailhead Fountain",
+};
+
+const tenKmSource: WaterSource = { id: 2, lat: 37.09, lon: -122.001, type: "drinking_water" };
+const twentyKmSource: WaterSource = { id: 3, lat: 37.18, lon: -121.995, type: "water_point" };
+const fortyKmSource: WaterSource = { id: 4, lat: 37.36, lon: -122.0, type: "drinking_water" };
+const offCorridorSource: WaterSource = { id: 5, lat: 37.15, lon: -121.5, type: "drinking_water" };
+
+const waterSources = [startFountain, tenKmSource, twentyKmSource, fortyKmSource, offCorridorSource];
+
+function createInput(isHotWeather: boolean): WaterStopPlanningInput {
+  return { route, waterSources, isHotWeather };
+}
+
+function closeToKm(actualM: number, expectedKm: number) {
+  expect(Math.abs(actualM - expectedKm * 1000)).toBeLessThan(500);
+}
+
+describe("planWaterStops", () => {
+  test("filters out sources beyond the route corridor", () => {
+    const result = planWaterStops(createInput(false));
+    expect(result.stops.map((s) => s.source.id)).not.toContain(offCorridorSource.id);
+  });
+
+  test("orders stops by distance along the route", () => {
+    const result = planWaterStops(createInput(true));
+    const distances = result.stops.map((s) => s.distanceAlongRouteM);
+    expect(distances).toEqual([...distances].sort((a, b) => a - b));
+  });
+
+  test("thins closely spaced sources in normal weather", () => {
+    const result = planWaterStops(createInput(false));
+    expect(result.stops.map((s) => s.source.id)).toEqual([
+      startFountain.id,
+      twentyKmSource.id,
+      fortyKmSource.id,
+    ]);
+    closeToKm(result.stops[0].distanceAlongRouteM, 0);
+    closeToKm(result.stops[1].distanceAlongRouteM, 20);
+    closeToKm(result.stops[2].distanceAlongRouteM, 40);
+  });
+
+  test("allows closer spacing in hot weather", () => {
+    const result = planWaterStops(createInput(true));
+    expect(result.stops.map((s) => s.source.id)).toEqual([
+      startFountain.id,
+      tenKmSource.id,
+      twentyKmSource.id,
+      fortyKmSource.id,
+    ]);
+  });
+
+  test("respects a custom corridor distance", () => {
+    const result = planWaterStops({ ...createInput(false), corridorDistanceM: 100 });
+    expect(result.stops.map((s) => s.source.id)).toEqual([startFountain.id, fortyKmSource.id]);
+  });
+
+  test("respects custom spacing overrides", () => {
+    const result = planWaterStops({ ...createInput(false), normalSpacingM: 5000 });
+    expect(result.stops).toHaveLength(4);
+  });
+
+  test("returns no stops when the corridor has no water sources", () => {
+    const result = planWaterStops({ ...createInput(true), waterSources: [] });
+    expect(result.stops).toHaveLength(0);
+    expect(result.totalDistanceM).toBeGreaterThan(0);
+  });
+});
+
+describe("buildWaterStopPrompt", () => {
+  test("includes hot weather emphasis", () => {
+    const output = planWaterStops(createInput(true));
+    const prompt = buildWaterStopPrompt(output);
+    expect(prompt).toContain("Hot weather");
+  });
+
+  test("omits hot weather emphasis in normal conditions", () => {
+    const output = planWaterStops(createInput(false));
+    const prompt = buildWaterStopPrompt(output);
+    expect(prompt).not.toContain("Hot weather");
+  });
+
+  test("describes each stop with a distance marker", () => {
+    const output = planWaterStops(createInput(false));
+    const prompt = buildWaterStopPrompt(output);
+    expect(prompt).toContain("Refill at Trailhead Fountain: 0.0 km");
+  });
+
+  test("flags unmarked water points for verification", () => {
+    const output = planWaterStops(createInput(false));
+    const prompt = buildWaterStopPrompt(output);
+    expect(prompt).toContain("unmarked source");
+  });
+
+  test("advises carrying extra water when the corridor has no sources", () => {
+    const output = planWaterStops({ ...createInput(true), waterSources: [] });
+    const prompt = buildWaterStopPrompt(output);
+    expect(prompt).toContain("No water sources found");
+    expect(prompt).toContain("carrying extra water");
+  });
+});


### PR DESCRIPTION
Adds the water stop planning skill: pure logic that turns route points and OSM `WaterSource` data into ordered hydration stop recommendations, plus a prompt builder for rider-facing refill guidance. Follows the `history-analysis` skill pattern (pure function module, `prompt.ts` builder, barrel `index.ts`, colocated eval).

Closes #14

The core logic in `plan.ts` filters `WaterSource`s to a corridor around the route (default 500m, configurable) using nearest-vertex distance rather than segment projection. That's a reasonable approximation for skill-level logic and keeps the implementation simple. It computes cumulative distance along the route once, then reuses it both to place each candidate source and to thin them by minimum spacing: 20km by default, 10km in hot weather. Widening or narrowing the spacing threshold based on temperature was simpler and more testable than reasoning about heat-adjusted target intervals, and it directly implements the issue's "closer spacing when hot" requirement.

Scope cut: this only reasons about the `WaterSource` data already returned by `findWaterSources` (fountains and water points). It doesn't add a store fallback via Google Maps or a reliability field, both mentioned in `docs/skills.md`. The underlying OSM data doesn't carry that signal yet, and store integration belongs with Food stop planning (#12) anyway. The prompt builder does flag `water_point` sources as unmarked in the rider guidance, since that's the one reliability signal the existing `WaterSource` type actually encodes.

## Demonstration

Given a hot 80km route through Death Valley with two known sources, `buildWaterStopPrompt` produces:

```
Plan drinking-water refill stops along this route for hydration. Recommend fountains, water points, and stores for topping up.

Hot weather. Emphasize hydration and have riders refill at every recommended stop even if not yet thirsty.

Refill at Furnace Creek Visitor Center: 0.0 km
Refill at Stovepipe Wells: 40.0 km (unmarked source, verify it's flowing)
```

## Testing

Unit tests in `water-stops.test.ts` cover corridor filtering (including a custom corridor distance), distance-along-route ordering, spacing behavior under normal vs. hot weather (including custom spacing overrides), the no-sources-in-corridor case, and the prompt builder's per-stop descriptions, heat emphasis, unmarked-source flag, and no-coverage messaging.
