### PR TITLE
Add route optimization skill

### DIFF
--- a/src/skills/route-optimization/evals/cases/scenarios.yaml
+++ b/src/skills/route-optimization/evals/cases/scenarios.yaml
@@ -1,0 +1,121 @@
+- description: "Familiar area, reuse from history"
+  vars:
+    findings_prompt: |-
+      Present the History Analysis research findings to the user:
+
+      - Relevant past rides in this area: 3
+      - Reusable segments: 2
+      - Typical distance from history: 54.0 km (max 110.0 km)
+
+      Use the present_route_plan tool with stage "present_findings".
+      Ask: "Would you like me to generate route options based on these findings?"
+    select_route_prompt: |-
+      Present the following synthesized route options to the user:
+
+      **Option 1** (road, 3 waypoints)
+      - Reusing "Panoramic Highway Loop" as a waypoint. It's a similar ride done before.
+      - Reusing "Hawk Hill Climb" as a waypoint. It's a similar ride done before.
+      - 2 known segment(s) available nearby as route building blocks.
+
+      **Option 2** (road, 1 waypoints)
+      - No prior rides matched the requested distance/elevation. The plan only anchors on the start point and needs additional waypoints (e.g. via geocoding) before routing.
+
+      Use the present_route_plan tool with stage "select_route".
+      Ask: "Which route would you like to select?"
+    query: "Plan a 60km ride from Mill Valley, prefer roads I know"
+  assert:
+    - type: llm-rubric
+      value: |
+        The response should:
+        - Recommend the option that reuses the rider's history (Option 1)
+        - Reference specific reused roads (Panoramic Highway Loop and/or Hawk Hill Climb)
+        - Mention the requested distance of about 60km
+        - Treat the rider's history as an asset for planning, not a constraint
+    - type: javascript
+      value: file://../../../../evals/scorers/route.ts:invokesSkills
+      config:
+        skills: ["History Analysis"]
+    - type: javascript
+      value: file://../../../../evals/scorers/route.ts:mentionsLocations
+      config:
+        locations: ["Panoramic Highway Loop", "Hawk Hill Climb"]
+    - type: javascript
+      value: file://../../../../evals/scorers/route.ts:distanceInRange
+      config:
+        target_km: 60
+        tolerance: 0.15
+
+- description: "New territory, no history match"
+  vars:
+    findings_prompt: |-
+      Present the History Analysis research findings to the user:
+
+      - Relevant past rides in this area: 0
+      - Reusable segments: 0
+      - Typical distance from history: 72.0 km (max 160.0 km)
+
+      Use the present_route_plan tool with stage "present_findings".
+      Ask: "Would you like me to generate route options based on these findings?"
+    select_route_prompt: |-
+      Present the following synthesized route options to the user:
+
+      **Option 1** (road, 1 waypoints)
+      - No prior rides matched the requested distance/elevation. The plan only anchors on the start point and needs additional waypoints (e.g. via geocoding) before routing.
+
+      Use the present_route_plan tool with stage "select_route".
+      Ask: "Which route would you like to select?"
+    query: "Plan a 70km ride around Santa Cruz"
+  assert:
+    - type: llm-rubric
+      value: |
+        The response should:
+        - Acknowledge that the rider has no prior rides in this area
+        - NOT claim familiarity with roads the rider hasn't ridden
+        - Note that more waypoints are needed before a route can be generated
+    - type: javascript
+      value: file://../../../../evals/scorers/route.ts:invokesSkills
+      config:
+        skills: ["History Analysis"]
+    - type: javascript
+      value: file://../../../../evals/scorers/route.ts:distanceInRange
+      config:
+        target_km: 70
+        tolerance: 0.15
+
+- description: "Partial reuse, gravel ride from Fairfax"
+  vars:
+    findings_prompt: |-
+      Present the History Analysis research findings to the user:
+
+      - Relevant past rides in this area: 1
+      - Reusable segments: 1
+      - Typical distance from history: 25.0 km (max 35.0 km)
+
+      Use the present_route_plan tool with stage "present_findings".
+      Ask: "Would you like me to generate route options based on these findings?"
+    select_route_prompt: |-
+      Present the following synthesized route options to the user:
+
+      **Option 1** (mountain, 2 waypoints)
+      - Reusing "Fairfax Ridge Connector" as a waypoint. It's a similar ride done before.
+      - 1 known segment(s) available nearby as route building blocks.
+
+      Use the present_route_plan tool with stage "select_route".
+      Ask: "Which route would you like to select?"
+    query: "Plan a 50km gravel ride from Fairfax, use familiar climbs where you can"
+  assert:
+    - type: llm-rubric
+      value: |
+        The response should:
+        - Acknowledge limited but existing familiarity with the area (one prior ride)
+        - Reference the known Fairfax Ridge Connector
+        - Suggest the gravel/mountain profile fits the request
+    - type: javascript
+      value: file://../../../../evals/scorers/route.ts:mentionsLocations
+      config:
+        locations: ["Fairfax Ridge Connector"]
+    - type: javascript
+      value: file://../../../../evals/scorers/route.ts:distanceInRange
+      config:
+        target_km: 50
+        tolerance: 0.15

--- a/src/skills/route-optimization/evals/prompt.txt
+++ b/src/skills/route-optimization/evals/prompt.txt
@@ -1,0 +1,11 @@
+{{findings_prompt}}
+
+## Route Options
+
+{{select_route_prompt}}
+
+## Route Planning Request
+
+{{query}}
+
+Based on the findings and route options above, write the message you would show the user to help them choose a route.

--- a/src/skills/route-optimization/evals/promptfooconfig.yaml
+++ b/src/skills/route-optimization/evals/promptfooconfig.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: "Route optimization skill. Does the synthesized guidance produce a good route recommendation?"
+
+prompts:
+  - file://prompt.txt
+
+providers:
+  - id: anthropic:messages:claude-sonnet-5
+    config:
+      temperature: 0.0
+      max_tokens: 1024
+
+defaultTest:
+  options:
+    provider: anthropic:messages:claude-sonnet-5
+
+tests: file://cases/scenarios.yaml

--- a/src/skills/route-optimization/index.ts
+++ b/src/skills/route-optimization/index.ts
@@ -1,0 +1,19 @@
+export { parseRouteRequest } from "./parse";
+export {
+  buildConfirmIntentPrompt,
+  buildPresentFinalPrompt,
+  buildPresentFindingsPrompt,
+  buildSelectRoutePrompt,
+} from "./prompt";
+export { synthesizeRoute } from "./synthesize";
+export type {
+  CyclingProfile,
+  DistanceTarget,
+  ElevationTarget,
+  FinalizedRoute,
+  RoutePreferences,
+  RouteRequest,
+  RouteSynthesisInput,
+  RouteSynthesisOutput,
+  WaypointGuidance,
+} from "./types";

--- a/src/skills/route-optimization/parse.ts
+++ b/src/skills/route-optimization/parse.ts
@@ -1,0 +1,67 @@
+import type { CyclingProfile, RouteRequest } from "./types";
+
+const KM_TO_M = 1000;
+const MI_TO_M = 1609.34;
+const DEFAULT_DISTANCE_TOLERANCE = 0.15;
+
+const distancePattern = /(\d+(?:\.\d+)?)\s*(km|kilometers?|kilometres?|mi|miles?)\b/i;
+const elevationPattern =
+  /(\d+(?:\.\d+)?)\s*(m|meters?|metres?|ft|feet)\s*(?:of\s+)?(?:climbing|elevation|gain|vert)/i;
+const startLocationPattern =
+  /\b(?:from|around|starting at|starting from)\s+([A-Z][\w\s]*?)(?=$|,|\bwith\b|\bthat\b|\bfor\b)/i;
+
+function parseDistance(query: string): RouteRequest["distance"] {
+  const match = query.match(distancePattern);
+  if (!match) {
+    throw new Error(`Could not find a distance in query: "${query}"`);
+  }
+  const value = Number.parseFloat(match[1]);
+  const unit = match[2].toLowerCase();
+  const meters = unit.startsWith("mi") ? value * MI_TO_M : value * KM_TO_M;
+  return { target: Math.round(meters), tolerance: DEFAULT_DISTANCE_TOLERANCE };
+}
+
+function parseElevation(query: string): RouteRequest["elevation"] | undefined {
+  const match = query.match(elevationPattern);
+  if (!match) return undefined;
+  const value = Number.parseFloat(match[1]);
+  const unit = match[2].toLowerCase();
+  const meters = unit.startsWith("ft") || unit.startsWith("feet") ? value * 0.3048 : value;
+  return { target: Math.round(meters) };
+}
+
+function parseStartLocation(query: string): string {
+  const match = query.match(startLocationPattern);
+  return match ? match[1].trim() : "";
+}
+
+function parseProfile(query: string): CyclingProfile | undefined {
+  if (/gravel|mountain|mtb|dirt/i.test(query)) return "mountain";
+  if (/rac(e|ing)|tempo/i.test(query)) return "racing";
+  return undefined;
+}
+
+function parsePreferences(query: string): RouteRequest["preferences"] {
+  const profile = parseProfile(query);
+  const loop = !/one[- ]way|point[- ]to[- ]point/i.test(query);
+  const preferFamiliarRoads = /favorite|familiar|roads? i know|know well/i.test(query);
+
+  const preferences: RouteRequest["preferences"] = { loop };
+  if (profile) preferences.profile = profile;
+  if (preferFamiliarRoads) preferences.preferFamiliarRoads = true;
+  return preferences;
+}
+
+/**
+ * Extracts distance, elevation, start location, and preferences from a free-text
+ * route request. The start location is a place name; resolving it to coordinates
+ * (via a geocoding tool) happens outside this pure parsing step.
+ */
+export function parseRouteRequest(query: string): RouteRequest {
+  return {
+    startLocation: parseStartLocation(query),
+    distance: parseDistance(query),
+    elevation: parseElevation(query),
+    preferences: parsePreferences(query),
+  };
+}

--- a/src/skills/route-optimization/prompt.ts
+++ b/src/skills/route-optimization/prompt.ts
@@ -1,0 +1,113 @@
+import type { RoutePath } from "../../graphhopper/server";
+import type { HistoryAnalysisOutput } from "../history-analysis";
+import type { RouteRequest, RouteSynthesisOutput } from "./types";
+
+function formatKm(meters: number): string {
+  return `${(meters / 1000).toFixed(1)} km`;
+}
+
+function formatDistanceLine(request: RouteRequest): string {
+  const { target, tolerance } = request.distance;
+  const range = tolerance ? ` (+/-${Math.round(tolerance * 100)}%)` : "";
+  return `- Distance: ${formatKm(target)}${range}`;
+}
+
+function formatElevationLine(request: RouteRequest): string | undefined {
+  if (!request.elevation?.target) return undefined;
+  return `- Elevation: ${Math.round(request.elevation.target)}m of climbing`;
+}
+
+function formatPreferencesLine(request: RouteRequest): string | undefined {
+  const prefs = request.preferences;
+  if (!prefs) return undefined;
+
+  const parts: string[] = [];
+  if (prefs.profile) parts.push(`profile: ${prefs.profile}`);
+  if (prefs.loop !== undefined) parts.push(prefs.loop ? "loop" : "point-to-point");
+  if (prefs.preferFamiliarRoads) parts.push("prefer familiar roads");
+
+  return parts.length > 0 ? `- Preferences: ${parts.join(", ")}` : undefined;
+}
+
+/**
+ * Prompt guidance for the confirm_intent checkpoint stage.
+ */
+export function buildConfirmIntentPrompt(request: RouteRequest): string {
+  const lines = [
+    "Present the following route request to the user for confirmation:",
+    "",
+    `- Start: ${request.startLocation || "not specified, ask the user"}`,
+    formatDistanceLine(request),
+    formatElevationLine(request),
+    formatPreferencesLine(request),
+    "",
+    'Use the present_route_plan tool with stage "confirm_intent".',
+    'Ask: "Does this match what you\'re looking for?"',
+  ].filter((line): line is string => line !== undefined);
+
+  return lines.join("\n");
+}
+
+/**
+ * Prompt guidance for the present_findings checkpoint stage. Summarizes the
+ * History Analysis skill's output before synthesis produces route candidates.
+ */
+export function buildPresentFindingsPrompt(history: HistoryAnalysisOutput): string {
+  const lines = [
+    "Present the History Analysis research findings to the user:",
+    "",
+    `- Relevant past rides in this area: ${history.relevantActivities.length}`,
+    `- Reusable segments: ${history.reusableSegments.length}`,
+    `- Typical distance from history: ${formatKm(history.preferences.distance.avg)} (max ${formatKm(history.preferences.distance.max)})`,
+    "",
+    'Use the present_route_plan tool with stage "present_findings".',
+    'Ask: "Would you like me to generate route options based on these findings?"',
+  ];
+
+  return lines.join("\n");
+}
+
+function formatCandidate(candidate: RouteSynthesisOutput, index: number): string {
+  return [
+    `**Option ${index + 1}** (${candidate.guidance.profile}, ${candidate.guidance.waypoints.length} waypoints)`,
+    ...candidate.rationale.map((r) => `- ${r}`),
+  ].join("\n");
+}
+
+/**
+ * Prompt guidance for the select_route checkpoint stage. Takes multiple
+ * synthesis outputs, e.g. from varying preferences across calls to synthesizeRoute.
+ */
+export function buildSelectRoutePrompt(candidates: RouteSynthesisOutput[]): string {
+  const lines = [
+    "Present the following synthesized route options to the user:",
+    "",
+    ...candidates.map((c, i) => formatCandidate(c, i)),
+    "",
+    'Use the present_route_plan tool with stage "select_route".',
+    'Ask: "Which route would you like to select?"',
+  ];
+
+  return lines.join("\n");
+}
+
+/**
+ * Prompt guidance for the present_final checkpoint stage, after the agent has
+ * called the GraphHopper route tool with the chosen candidate's waypoints.
+ */
+export function buildPresentFinalPrompt(chosen: RouteSynthesisOutput, path: RoutePath): string {
+  const lines = [
+    "Present the final route to the user:",
+    "",
+    `- Distance: ${formatKm(path.distance)}`,
+    `- Duration: ${Math.round(path.time / 60000)} min`,
+    `- Profile: ${chosen.guidance.profile}`,
+    ...chosen.rationale.map((r) => `- ${r}`),
+    "",
+    "The route is ready to hand to generateGpx for a downloadable GPX file.",
+    'Use the present_route_plan tool with stage "present_final".',
+    'Ask: "Ready to generate the GPX file?"',
+  ];
+
+  return lines.join("\n");
+}

--- a/src/skills/route-optimization/route-optimization.test.ts
+++ b/src/skills/route-optimization/route-optimization.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, test } from "bun:test";
+import type { RoutePath } from "../../graphhopper/server";
+import type { ActivitySummary, HistoryAnalysisOutput, SegmentSummary } from "../history-analysis";
+import { parseRouteRequest } from "./parse";
+import {
+  buildConfirmIntentPrompt,
+  buildPresentFinalPrompt,
+  buildPresentFindingsPrompt,
+  buildSelectRoutePrompt,
+} from "./prompt";
+import { synthesizeRoute } from "./synthesize";
+import type { RouteRequest, RouteSynthesisOutput } from "./types";
+
+const activities: ActivitySummary[] = [
+  {
+    id: 1,
+    name: "Coastal Loop",
+    distance: 58000,
+    elevationGain: 500,
+    movingTime: 8000,
+    startLatLng: [37.9, -122.5],
+  },
+  {
+    id: 2,
+    name: "Ridge Climb",
+    distance: 61000,
+    elevationGain: 900,
+    movingTime: 9000,
+    startLatLng: [37.91, -122.51],
+  },
+  {
+    id: 3,
+    name: "Valley Cruise",
+    distance: 20000,
+    elevationGain: 100,
+    movingTime: 3000,
+    startLatLng: [37.92, -122.52],
+  },
+];
+
+const segments: SegmentSummary[] = [
+  { id: 1, name: "Ridge Segment", distance: 3000, avgGrade: 6, elevDifference: 180 },
+];
+
+const history: HistoryAnalysisOutput = {
+  relevantActivities: activities,
+  reusableSegments: segments,
+  preferences: {
+    rideCount: 50,
+    distance: { avg: 50000, max: 80000 },
+    elevation: { avg: 600, max: 1200 },
+    duration: { avg: 7000, max: 12000 },
+  },
+};
+
+const start: [number, number] = [37.89, -122.49];
+
+function createRequest(overrides: Partial<RouteRequest> = {}): RouteRequest {
+  return {
+    startLocation: "Mill Valley",
+    distance: { target: 60000, tolerance: 0.15 },
+    preferences: { loop: true },
+    ...overrides,
+  };
+}
+
+describe("parseRouteRequest", () => {
+  test("parses distance in kilometers", () => {
+    const request = parseRouteRequest("Plan a 60km ride from Mill Valley");
+    expect(request.distance.target).toBe(60000);
+  });
+
+  test("parses distance in miles", () => {
+    const request = parseRouteRequest("Plan a 40 mile ride from Fairfax");
+    expect(request.distance.target).toBe(Math.round(40 * 1609.34));
+  });
+
+  test("parses elevation given in feet of climbing", () => {
+    const request = parseRouteRequest("60km ride with 3000ft of climbing from Fairfax");
+    expect(request.elevation?.target).toBe(Math.round(3000 * 0.3048));
+  });
+
+  test("parses elevation given in meters of elevation gain", () => {
+    const request = parseRouteRequest("60km ride with 900m of elevation gain from Fairfax");
+    expect(request.elevation?.target).toBe(900);
+  });
+
+  test("omits elevation when not mentioned", () => {
+    const request = parseRouteRequest("Plan a 60km ride from Mill Valley");
+    expect(request.elevation).toBeUndefined();
+  });
+
+  test("extracts the start location", () => {
+    const request = parseRouteRequest("Plan a 60km ride from Mill Valley with some climbing");
+    expect(request.startLocation).toBe("Mill Valley");
+  });
+
+  test("defaults to a loop when not specified", () => {
+    const request = parseRouteRequest("Plan a 60km ride from Mill Valley");
+    expect(request.preferences?.loop).toBe(true);
+  });
+
+  test("detects a point-to-point request", () => {
+    const request = parseRouteRequest("Plan a 60km point-to-point ride from Mill Valley");
+    expect(request.preferences?.loop).toBe(false);
+  });
+
+  test("detects a mountain profile from gravel", () => {
+    const request = parseRouteRequest("Plan a 60km gravel ride from Mill Valley");
+    expect(request.preferences?.profile).toBe("mountain");
+  });
+
+  test("detects a racing profile", () => {
+    const request = parseRouteRequest("Plan a 60km race pace ride from Mill Valley");
+    expect(request.preferences?.profile).toBe("racing");
+  });
+
+  test("detects a preference for familiar roads", () => {
+    const request = parseRouteRequest("Plan a 60km ride on my favorite roads from Mill Valley");
+    expect(request.preferences?.preferFamiliarRoads).toBe(true);
+  });
+
+  test("throws when no distance is found", () => {
+    expect(() => parseRouteRequest("Plan a ride from Mill Valley")).toThrow();
+  });
+});
+
+describe("synthesizeRoute", () => {
+  test("anchors on activities within tolerance, closest first", () => {
+    const result = synthesizeRoute({ history, request: createRequest(), start });
+    expect(result.reusedActivities.map((a) => a.id)).toEqual([2, 1]);
+    expect(result.guidance.waypoints).toEqual([
+      start,
+      activities[1].startLatLng,
+      activities[0].startLatLng,
+      start,
+    ]);
+  });
+
+  test("falls back to the start point alone when nothing matches", () => {
+    const request = createRequest({ distance: { target: 5000, tolerance: 0.15 } });
+    const result = synthesizeRoute({ history, request, start });
+    expect(result.reusedActivities).toHaveLength(0);
+    expect(result.guidance.waypoints).toEqual([start]);
+    expect(result.rationale.some((r) => r.includes("No prior rides matched"))).toBe(true);
+  });
+
+  test("skips reuse when preferFamiliarRoads is false", () => {
+    const request = createRequest({ preferences: { loop: true, preferFamiliarRoads: false } });
+    const result = synthesizeRoute({ history, request, start });
+    expect(result.reusedActivities).toHaveLength(0);
+    expect(result.guidance.waypoints).toEqual([start]);
+  });
+
+  test("omits the closing waypoint when loop is false", () => {
+    const request = createRequest({ preferences: { loop: false } });
+    const result = synthesizeRoute({ history, request, start });
+    expect(result.guidance.waypoints).toEqual([
+      start,
+      activities[1].startLatLng,
+      activities[0].startLatLng,
+    ]);
+  });
+
+  test("defaults to the road profile", () => {
+    const result = synthesizeRoute({ history, request: createRequest(), start });
+    expect(result.guidance.profile).toBe("road");
+  });
+
+  test("passes reusable segments through from history", () => {
+    const result = synthesizeRoute({ history, request: createRequest(), start });
+    expect(result.reusedSegments).toEqual(segments);
+  });
+});
+
+describe("buildConfirmIntentPrompt", () => {
+  test("includes the parsed request details", () => {
+    const prompt = buildConfirmIntentPrompt(
+      createRequest({
+        elevation: { target: 900 },
+        preferences: { profile: "mountain", loop: true, preferFamiliarRoads: true },
+      }),
+    );
+    expect(prompt).toContain("Mill Valley");
+    expect(prompt).toContain("60.0 km");
+    expect(prompt).toContain("900m of climbing");
+    expect(prompt).toContain("profile: mountain");
+    expect(prompt).toContain("prefer familiar roads");
+  });
+});
+
+describe("buildPresentFindingsPrompt", () => {
+  test("summarizes history analysis output", () => {
+    const prompt = buildPresentFindingsPrompt(history);
+    expect(prompt).toContain("History Analysis");
+    expect(prompt).toContain("Relevant past rides in this area: 3");
+    expect(prompt).toContain("Reusable segments: 1");
+    expect(prompt).toContain("50.0 km");
+    expect(prompt).toContain("80.0 km");
+  });
+});
+
+describe("buildSelectRoutePrompt", () => {
+  test("presents each synthesized candidate", () => {
+    const familiar = synthesizeRoute({ history, request: createRequest(), start });
+    const exploratory = synthesizeRoute({
+      history,
+      request: createRequest({ preferences: { loop: true, preferFamiliarRoads: false } }),
+      start,
+    });
+    const candidates: RouteSynthesisOutput[] = [familiar, exploratory];
+
+    const prompt = buildSelectRoutePrompt(candidates);
+    expect(prompt).toContain("Option 1");
+    expect(prompt).toContain("Option 2");
+    expect(prompt).toContain("Ridge Climb");
+    expect(prompt).toContain("No prior rides matched");
+  });
+});
+
+describe("buildPresentFinalPrompt", () => {
+  test("includes the routed distance and duration", () => {
+    const chosen = synthesizeRoute({ history, request: createRequest(), start });
+    const path: RoutePath = {
+      distance: 60500,
+      time: 9000000,
+      points: {
+        coordinates: [
+          [-122.5, 37.9, 10],
+          [-122.51, 37.91, 20],
+        ],
+      },
+      instructions: [],
+    };
+
+    const prompt = buildPresentFinalPrompt(chosen, path);
+    expect(prompt).toContain("60.5 km");
+    expect(prompt).toContain("150 min");
+    expect(prompt).toContain("generateGpx");
+  });
+});

--- a/src/skills/route-optimization/synthesize.ts
+++ b/src/skills/route-optimization/synthesize.ts
@@ -1,0 +1,96 @@
+import type { ActivitySummary } from "../history-analysis";
+import type { RouteRequest, RouteSynthesisInput, RouteSynthesisOutput } from "./types";
+
+const MAX_REUSED_ANCHORS = 2;
+const POINT_EPSILON = 1e-4;
+
+function pointsEqual(a: [number, number], b: [number, number]): boolean {
+  return Math.abs(a[0] - b[0]) < POINT_EPSILON && Math.abs(a[1] - b[1]) < POINT_EPSILON;
+}
+
+function isWithinTolerance(activity: ActivitySummary, request: RouteRequest): boolean {
+  const { target, tolerance = 0.15 } = request.distance;
+  const distanceOk = Math.abs(activity.distance - target) <= target * tolerance;
+  if (!distanceOk) return false;
+
+  const elevationTarget = request.elevation?.target;
+  if (elevationTarget === undefined) return true;
+  return Math.abs(activity.elevationGain - elevationTarget) <= elevationTarget * tolerance;
+}
+
+function fitScore(activity: ActivitySummary, request: RouteRequest): number {
+  const distanceScore =
+    Math.abs(activity.distance - request.distance.target) / request.distance.target;
+  const elevationTarget = request.elevation?.target;
+  const elevationScore =
+    elevationTarget === undefined
+      ? 0
+      : Math.abs(activity.elevationGain - elevationTarget) / Math.max(elevationTarget, 1);
+  return distanceScore + elevationScore;
+}
+
+function selectAnchors(activities: ActivitySummary[], request: RouteRequest): ActivitySummary[] {
+  if (request.preferences?.preferFamiliarRoads === false) return [];
+
+  return activities
+    .filter((activity) => isWithinTolerance(activity, request))
+    .sort((a, b) => fitScore(a, request) - fitScore(b, request))
+    .slice(0, MAX_REUSED_ANCHORS);
+}
+
+function buildWaypoints(
+  start: [number, number],
+  anchors: ActivitySummary[],
+  loop: boolean,
+): [number, number][] {
+  if (anchors.length === 0) return [start];
+
+  const points: [number, number][] = [start, ...anchors.map((a) => a.startLatLng)];
+  const last = points[points.length - 1];
+  if (loop && !pointsEqual(last, start)) points.push(start);
+  return points;
+}
+
+function buildRationale(anchors: ActivitySummary[], reusedSegmentCount: number): string[] {
+  const rationale: string[] = [];
+
+  if (anchors.length === 0) {
+    rationale.push(
+      "No prior rides matched the requested distance/elevation. The plan only anchors on the start point and needs additional waypoints (e.g. via geocoding) before routing.",
+    );
+  } else {
+    for (const anchor of anchors) {
+      rationale.push(`Reusing "${anchor.name}" as a waypoint. It's a similar ride done before.`);
+    }
+  }
+
+  if (reusedSegmentCount > 0) {
+    rationale.push(
+      `${reusedSegmentCount} known segment(s) available nearby as route building blocks.`,
+    );
+  }
+
+  return rationale;
+}
+
+/**
+ * Turns ride history plus a route request into waypoint guidance an agent can
+ * pass to the GraphHopper `route` tool. Anchors on prior activities whose
+ * distance and elevation are close to the request; falls back to the start
+ * point alone when nothing in history is a close match.
+ */
+export function synthesizeRoute(input: RouteSynthesisInput): RouteSynthesisOutput {
+  const { history, request, start } = input;
+  const profile = request.preferences?.profile ?? "road";
+  const loop = request.preferences?.loop ?? true;
+
+  const anchors = selectAnchors(history.relevantActivities, request);
+  const waypoints = buildWaypoints(start, anchors, loop);
+
+  return {
+    guidance: { waypoints, profile },
+    reusedActivities: anchors,
+    reusedSegments: history.reusableSegments,
+    rationale: buildRationale(anchors, history.reusableSegments.length),
+  };
+}

--- a/src/skills/route-optimization/types.ts
+++ b/src/skills/route-optimization/types.ts
@@ -1,0 +1,59 @@
+import type { RoutePath } from "../../graphhopper/server";
+import type { ActivitySummary, HistoryAnalysisOutput, SegmentSummary } from "../history-analysis";
+
+export type CyclingProfile = "road" | "mountain" | "racing";
+
+export interface DistanceTarget {
+  target: number;
+  tolerance?: number;
+}
+
+export interface ElevationTarget {
+  target?: number;
+  max?: number;
+}
+
+export interface RoutePreferences {
+  profile?: CyclingProfile;
+  loop?: boolean;
+  preferFamiliarRoads?: boolean;
+}
+
+export interface RouteRequest {
+  startLocation: string;
+  distance: DistanceTarget;
+  elevation?: ElevationTarget;
+  preferences?: RoutePreferences;
+}
+
+/**
+ * Waypoints in the shape the GraphHopper `route` tool expects, ready to be
+ * passed straight through as its `waypoints` argument.
+ */
+export interface WaypointGuidance {
+  waypoints: [number, number][];
+  profile: CyclingProfile;
+}
+
+export interface RouteSynthesisOutput {
+  guidance: WaypointGuidance;
+  reusedActivities: ActivitySummary[];
+  reusedSegments: SegmentSummary[];
+  rationale: string[];
+}
+
+export interface RouteSynthesisInput {
+  history: HistoryAnalysisOutput;
+  request: RouteRequest;
+  start: [number, number];
+}
+
+/**
+ * A route after the agent has called the GraphHopper `route` tool with a
+ * synthesis output's waypoints, ready to hand to `generateGpx`.
+ */
+export interface FinalizedRoute {
+  path: RoutePath;
+  name: string;
+  description: string;
+}


### PR DESCRIPTION
Adds the Route Optimization skill, following the pattern established by `src/skills/history-analysis`: pure logic plus prompt builders, no MCP calls. `parseRouteRequest` turns a free-text query into a structured `RouteRequest` (distance/elevation targets, start location, preferences) using deterministic regex extraction rather than an LLM call. `synthesizeRoute` combines that request with `HistoryAnalysisOutput` to produce `WaypointGuidance`, an array of `[lat, lng]` waypoints in the exact shape the GraphHopper `route` tool expects, plus a `profile` and a human-readable `rationale`. `prompt.ts` has one builder per checkpoint stage named in the issue: `confirm_intent`, `present_findings`, `select_route`, `present_final`.

Closes #10.

## Design Notes

- `synthesizeRoute` anchors on past activities whose distance (and elevation, if requested) falls within a tolerance of the target, sorted by closeness, capped at two reused waypoints. When nothing in history is a close match, it falls back to a single-point plan (just the start) and flags in the rationale that the agent needs to gather more waypoints (e.g. via geocoding) before it's routable, rather than fabricating a fake loop.
- `SegmentSummary` (from `history-analysis`) has no coordinates, so reused segments can't contribute waypoints directly. They show up in the rationale as supporting context ("N known segment(s) available nearby") rather than as route anchors.
- `present_final`'s prompt builder takes the actual `RoutePath` returned by the GraphHopper `route` tool (not just the synthesis output), so the final summary reports real distance/duration and explicitly hands off to `generateGpx`.
- The issue's flow is "intent -> research -> synthesis -> output", so I built four stage prompts, skipping the `refine_route` stage that exists in `checkpoint/tool.ts`'s five-stage `WorkflowStage` type but wasn't part of this issue's scope.

## Scope Cut

No orchestrator wiring MCP servers (GraphHopper geocode/route, Strava, etc.) together. Per the issue guardrail, that's the roadmap work described in `docs/architecture.md` (~lines 277-294), not this PR. This skill produces guidance; an agent still has to call `geocode`, `route`, and `generateGpx` itself using that guidance.

## Verification

Unit tests cover `parseRouteRequest` (distance/elevation/unit parsing, start-location extraction, profile and preference detection, the no-distance error case), `synthesizeRoute` (tolerance-based anchor selection and ordering, the no-match fallback, `preferFamiliarRoads: false`, loop vs. point-to-point waypoint lists, segment pass-through), and each of the four prompt builders. `bun test ./src/`, `bunx @biomejs/biome check .`, and `bunx tsc --noEmit` all ran clean against the new code (biome's only findings are pre-existing warnings in `src/graphhopper/graphhopper.test.ts`, untouched by this PR).

I couldn't actually run `bunx promptfoo eval` locally. It crashes at module-load time with a `ZodError` inside `@adaline/google`, and the same crash reproduces on the existing `src/skills/history-analysis/evals/promptfooconfig.yaml`, so it's a pre-existing environment issue, not something introduced here. I confirmed the new config and test-case YAML both parse correctly and that the scorer `file://` paths (`../../../../evals/scorers/route.ts`) resolve to the right file.

## Demonstration

Sample prompt-builder output for `parseRouteRequest("Plan a 60km ride from Mill Valley, prefer roads I know, with some climbing")`, followed by `synthesizeRoute` against a small history fixture (one activity, "Panoramic Highway Loop", within tolerance; one, "Hawk Hill Climb", outside it) and each of the four stage prompts:

```
=== parseRouteRequest ===
{
  "startLocation": "Mill Valley",
  "distance": {
    "target": 60000,
    "tolerance": 0.15
  },
  "preferences": {
    "loop": true,
    "preferFamiliarRoads": true
  }
}

=== buildConfirmIntentPrompt ===
Present the following route request to the user for confirmation:

- Start: Mill Valley
- Distance: 60.0 km (+/-15%)
- Preferences: loop, prefer familiar roads

Use the present_route_plan tool with stage "confirm_intent".
Ask: "Does this match what you're looking for?"

=== buildPresentFindingsPrompt ===
Present the History Analysis research findings to the user:

- Relevant past rides in this area: 2
- Reusable segments: 1
- Typical distance from history: 54.0 km (max 110.0 km)

Use the present_route_plan tool with stage "present_findings".
Ask: "Would you like me to generate route options based on these findings?"

=== buildSelectRoutePrompt ===
Present the following synthesized route options to the user:

**Option 1** (road, 3 waypoints)
- Reusing "Panoramic Highway Loop" as a waypoint. It's a similar ride done before.
- 1 known segment(s) available nearby as route building blocks.

Use the present_route_plan tool with stage "select_route".
Ask: "Which route would you like to select?"

=== buildPresentFinalPrompt ===
Present the final route to the user:

- Distance: 61.2 km
- Duration: 155 min
- Profile: road
- Reusing "Panoramic Highway Loop" as a waypoint. It's a similar ride done before.
- 1 known segment(s) available nearby as route building blocks.

The route is ready to hand to generateGpx for a downloadable GPX file.
Use the present_route_plan tool with stage "present_final".
Ask: "Ready to generate the GPX file?"
```
