### PR TITLE
Add narrative research skill

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -16,14 +16,14 @@ History Analysis and Narrative Research have code today. The rest are design spe
 | Weather Planning | 🔜 Planned | - |
 | Food Stop Planning | 🔜 Planned | - |
 | Water Stop Planning | 🔜 Planned | - |
-| Narrative Research | ✅ Implemented | `src/skills/ride-reports/` |
+| Narrative Research | ✅ Implemented | `src/skills/ride-reports/`, `src/skills/narrative-research/` |
 | Safety Assessment | 🔜 Planned | - |
 | Nutrition Planning | 🔜 Planned | - |
 | Clothing Planning | 🔜 Planned | - |
 
 Route Optimization depends on the GraphHopper tool, which exists in `src/graphhopper/`. The skill that drives it does not exist yet.
 
-Narrative Research's web search step covers ride reports and forum posts only. PJAMM narrative synthesis (step 2 of its research pattern) is not yet built.
+Narrative Research splits across two packages: `ride-reports/` runs the web search step, covering ride reports and forum posts only, and `narrative-research/` synthesizes its findings plus named route places into rider-facing notes and a presentation prompt. PJAMM narrative synthesis (step 2 of its research pattern) is cut pending the PJAMM API spike ([#15](https://github.com/bendrucker/route-agent/issues/15)).
 
 ## Skill Architecture {#skill-architecture}
 

--- a/src/skills/narrative-research/evals/cases/scenarios.yaml
+++ b/src/skills/narrative-research/evals/cases/scenarios.yaml
@@ -1,0 +1,35 @@
+- description: "Findings with a matched place: notes woven into the route narrative"
+  vars:
+    narrative_prompt: |-
+      Weave local knowledge into the final route presentation as narrative notes, not a research appendix. Write in a local-intel voice ("watch for...", "locals recommend...") and integrate each note at the point in the write-up where it's relevant, rather than listing them separately at the end.
+
+      hazard near North Gate: Loose gravel on the descent past the North Gate (per Mt Diablo north gate descent, watch the gravel)
+      condition: Summit road closed to cars on weekend mornings (per Climbing Mt Diablo: a complete guide)
+      recommendation near ranger station: Fill water bottles at the ranger station near the base before the climb (per Climbing Mt Diablo: a complete guide)
+    route_summary: |
+      A 42-mile loop up Mount Diablo via the North Gate entrance, past the ranger station, to the summit and back down South Gate Road.
+  assert:
+    - type: llm-rubric
+      value: |
+        The response should:
+        - Mention the loose gravel hazard at the point in the write-up describing the North Gate descent, not in a separate bulleted "local knowledge" section
+        - Mention the weekend morning car closure and the ranger station water fill as part of the narrative flow of the route description
+        - Present the hazard prominently enough that a rider would not miss it
+        - Attribute notes to their sources (by name, not necessarily a raw URL)
+        - NOT fabricate any additional hazards, conditions, or recommendations beyond what's given
+
+- description: "No narrative notes: route presented without a fabricated local-intel section"
+  vars:
+    narrative_prompt: |-
+      Weave local knowledge into the final route presentation as narrative notes, not a research appendix. Write in a local-intel voice ("watch for...", "locals recommend...") and integrate each note at the point in the write-up where it's relevant, rather than listing them separately at the end.
+
+      No narrative notes were found for this route. Skip narrative notes entirely rather than inventing local intel, and present the route on the strength of the other research.
+    route_summary: |
+      A 28-mile out-and-back along Willow Creek Flats, through rural farmland with no significant climbs.
+  assert:
+    - type: llm-rubric
+      value: |
+        The response should:
+        - Present the route plan normally, based on the route context given
+        - NOT invent hazards, conditions, recommendations, or any "local knowledge" section to fill the gap
+        - NOT hedge repeatedly or apologize at length about the absence of local intel; a brief or no mention is fine

--- a/src/skills/narrative-research/evals/prompt.txt
+++ b/src/skills/narrative-research/evals/prompt.txt
@@ -1,0 +1,7 @@
+{{narrative_prompt}}
+
+## Route Context
+
+{{route_summary}}
+
+Present the final route plan, incorporating the notes above naturally into the write-up.

--- a/src/skills/narrative-research/evals/promptfooconfig.yaml
+++ b/src/skills/narrative-research/evals/promptfooconfig.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: "Narrative research skill. Are local knowledge notes woven into the route presentation as narrative, and does the agent degrade gracefully when there's nothing to weave in?"
+
+prompts:
+  - file://prompt.txt
+
+providers:
+  - id: anthropic:messages:claude-sonnet-5
+    config:
+      temperature: 0.0
+      max_tokens: 1024
+
+defaultTest:
+  options:
+    provider: anthropic:messages:claude-sonnet-5
+
+tests: file://cases/scenarios.yaml

--- a/src/skills/narrative-research/index.ts
+++ b/src/skills/narrative-research/index.ts
@@ -1,0 +1,3 @@
+export { buildNarrativePrompt } from "./prompt";
+export { synthesizeNarrative } from "./synthesize";
+export type { NarrativeNote, NarrativeResearchOutput, RoutePlace } from "./types";

--- a/src/skills/narrative-research/narrative-research.test.ts
+++ b/src/skills/narrative-research/narrative-research.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import type { RideReportsSummary } from "../ride-reports";
+import { buildNarrativePrompt } from "./prompt";
+import { synthesizeNarrative } from "./synthesize";
+import type { NarrativeResearchOutput, RoutePlace } from "./types";
+
+const forumSource = { url: "https://reddit.com/r/cycling/abc", title: "Mt Diablo ride report" };
+const blogSource = {
+  url: "https://example-cycling-blog.com/mt-diablo",
+  title: "Climbing Mt Diablo",
+};
+
+const summary: RideReportsSummary = {
+  hazards: [
+    {
+      category: "hazard",
+      summary: "Loose gravel on the descent past the North Gate",
+      source: forumSource,
+    },
+  ],
+  conditions: [
+    {
+      category: "condition",
+      summary: "Summit road closed to cars on weekend mornings",
+      source: forumSource,
+    },
+  ],
+  recommendations: [
+    {
+      category: "recommendation",
+      summary: "Fill water bottles at the ranger station before the climb",
+      source: blogSource,
+    },
+  ],
+  sourceCount: 2,
+};
+
+const places: RoutePlace[] = [
+  { name: "North Gate", kind: "landmark" },
+  { name: "Ranger Station", kind: "landmark" },
+];
+
+describe("synthesizeNarrative", () => {
+  test("orders notes hazards, then conditions, then recommendations", () => {
+    const result = synthesizeNarrative(summary, places);
+    expect(result.notes.map((n) => n.category)).toEqual(["hazard", "condition", "recommendation"]);
+  });
+
+  test("matches place case-insensitively as a substring of the summary", () => {
+    const result = synthesizeNarrative(summary, places);
+    expect(result.notes[0]?.place).toBe("North Gate");
+    expect(result.notes[2]?.place).toBe("Ranger Station");
+  });
+
+  test("leaves place undefined when nothing matches", () => {
+    const result = synthesizeNarrative(summary, places);
+    expect(result.notes[1]?.place).toBeUndefined();
+  });
+
+  test("leaves place undefined when no places are given", () => {
+    const result = synthesizeNarrative(summary);
+    expect(result.notes.every((n) => n.place === undefined)).toBe(true);
+  });
+
+  test("passes sourceCount through unchanged", () => {
+    const result = synthesizeNarrative(summary, places);
+    expect(result.sourceCount).toBe(2);
+  });
+
+  test("handles an empty summary", () => {
+    const result = synthesizeNarrative({
+      hazards: [],
+      conditions: [],
+      recommendations: [],
+      sourceCount: 0,
+    });
+    expect(result).toEqual({ notes: [], sourceCount: 0 });
+  });
+});
+
+describe("buildNarrativePrompt", () => {
+  const output: NarrativeResearchOutput = synthesizeNarrative(summary, places);
+
+  test("includes the core weave-not-appendix instruction", () => {
+    const prompt = buildNarrativePrompt(output);
+    expect(prompt).toContain("not a research appendix");
+    expect(prompt).toContain("local-intel voice");
+  });
+
+  test("includes note lines with place and source attribution", () => {
+    const prompt = buildNarrativePrompt(output);
+    expect(prompt).toContain(
+      "hazard near North Gate: Loose gravel on the descent past the North Gate (per Mt Diablo ride report)",
+    );
+    expect(prompt).toContain(
+      "recommendation near Ranger Station: Fill water bottles at the ranger station before the climb (per Climbing Mt Diablo)",
+    );
+  });
+
+  test("omits place from a note line when nothing matched", () => {
+    const prompt = buildNarrativePrompt(output);
+    expect(prompt).toContain(
+      "condition: Summit road closed to cars on weekend mornings (per Mt Diablo ride report)",
+    );
+  });
+
+  test("omits degradation guidance when there are notes", () => {
+    const prompt = buildNarrativePrompt(output);
+    expect(prompt).not.toContain("Skip narrative notes entirely");
+  });
+
+  test("emits degradation guidance instead of note lines when there are none", () => {
+    const prompt = buildNarrativePrompt({ notes: [], sourceCount: 0 });
+    expect(prompt).toContain("Skip narrative notes entirely");
+    expect(prompt).toContain("present the route on the strength of the other research");
+  });
+});

--- a/src/skills/narrative-research/prompt.ts
+++ b/src/skills/narrative-research/prompt.ts
@@ -1,0 +1,24 @@
+import type { NarrativeNote, NarrativeResearchOutput } from "./types";
+
+const corePrompt = `Weave local knowledge into the final route presentation as narrative notes, not a research appendix. Write in a local-intel voice ("watch for...", "locals recommend...") and integrate each note at the point in the write-up where it's relevant, rather than listing them separately at the end.`;
+
+function describeNote(note: NarrativeNote): string {
+  const location = note.place ? ` near ${note.place}` : "";
+  return `${note.category}${location}: ${note.summary} (per ${note.source.title})`;
+}
+
+function notesContext(output: NarrativeResearchOutput): string {
+  if (output.notes.length === 0) return "";
+  return output.notes.map(describeNote).join("\n");
+}
+
+const degradationGuidance = `No narrative notes were found for this route. Skip narrative notes entirely rather than inventing local intel, and present the route on the strength of the other research.`;
+
+function degradationContext(output: NarrativeResearchOutput): string {
+  return output.notes.length === 0 ? degradationGuidance : "";
+}
+
+export function buildNarrativePrompt(output: NarrativeResearchOutput): string {
+  const sections = [corePrompt, notesContext(output), degradationContext(output)].filter(Boolean);
+  return sections.join("\n\n");
+}

--- a/src/skills/narrative-research/synthesize.ts
+++ b/src/skills/narrative-research/synthesize.ts
@@ -1,0 +1,30 @@
+import type { LocalKnowledgeFinding, RideReportsSummary } from "../ride-reports";
+import type { NarrativeNote, NarrativeResearchOutput, RoutePlace } from "./types";
+
+// Naive substring match: no fuzzy matching, so place names that don't appear verbatim
+// in a finding's summary (abbreviations, alternate spellings) won't be linked.
+function matchPlace(summary: string, places: RoutePlace[]): string | undefined {
+  const lowerSummary = summary.toLowerCase();
+  return places.find((place) => lowerSummary.includes(place.name.toLowerCase()))?.name;
+}
+
+function toNote(finding: LocalKnowledgeFinding, places: RoutePlace[]): NarrativeNote {
+  return {
+    category: finding.category,
+    summary: finding.summary,
+    source: finding.source,
+    place: matchPlace(finding.summary, places),
+  };
+}
+
+export function synthesizeNarrative(
+  summary: RideReportsSummary,
+  places: RoutePlace[] = [],
+): NarrativeResearchOutput {
+  const findings = [...summary.hazards, ...summary.conditions, ...summary.recommendations];
+
+  return {
+    notes: findings.map((finding) => toNote(finding, places)),
+    sourceCount: summary.sourceCount,
+  };
+}

--- a/src/skills/narrative-research/types.ts
+++ b/src/skills/narrative-research/types.ts
@@ -1,0 +1,18 @@
+import type { LocalKnowledgeCategory, Source } from "../ride-reports";
+
+export interface RoutePlace {
+  name: string;
+  kind?: "climb" | "town" | "landmark" | "intersection";
+}
+
+export interface NarrativeNote {
+  category: LocalKnowledgeCategory;
+  summary: string;
+  source: Source;
+  place?: string;
+}
+
+export interface NarrativeResearchOutput {
+  notes: NarrativeNote[];
+  sourceCount: number;
+}


### PR DESCRIPTION
Adds `src/skills/narrative-research/`, a synthesis layer over `ride-reports/` that turns a `RideReportsSummary` plus named route places into rider-facing route notes and a presentation-time prompt.

`synthesizeNarrative` concatenates hazards, then conditions, then recommendations, with no separate sort. Priority ordering falls out of that concatenation. It also matches each finding to a route place via a case-insensitive substring check of the place name within the finding's summary. That match is intentionally naive: it won't catch abbreviations or alternate spellings, and a one-line comment on `matchPlace` in `synthesize.ts` calls that out.

`buildNarrativePrompt` instructs the model to weave notes into the route write-up in local-intel voice ("watch for...", "locals recommend...") at the point where they're relevant, rather than as a bulleted appendix. When there are no notes, it swaps in degradation guidance instead: skip narrative notes entirely, don't fabricate local intel, present the route on the strength of the other research.

PJAMM narrative synthesis (step 2 of the Narrative Research research pattern in `docs/skills.md`) is cut from this PR. The PJAMM client doesn't exist yet and is blocked on the API spike (#15), so there's nothing to synthesize from. `docs/skills.md` now reflects that Narrative Research spans `ride-reports/` (search) and `narrative-research/` (synthesis), with PJAMM still pending.

## Demonstration

For a hazard, a condition, and a recommendation where two of the three match a named route place (`North Gate`, `ranger station`), `buildNarrativePrompt` produces:

```
Weave local knowledge into the final route presentation as narrative notes, not a research appendix. Write in a local-intel voice ("watch for...", "locals recommend...") and integrate each note at the point in the write-up where it's relevant, rather than listing them separately at the end.

hazard near North Gate: Loose gravel on the descent past the North Gate (per Mt Diablo north gate descent, watch the gravel)
condition: Summit road closed to cars on weekend mornings (per Climbing Mt Diablo: a complete guide)
recommendation near ranger station: Fill water bottles at the ranger station near the base before the climb (per Climbing Mt Diablo: a complete guide)
```

With an empty summary, it produces:

```
Weave local knowledge into the final route presentation as narrative notes, not a research appendix. Write in a local-intel voice ("watch for...", "locals recommend...") and integrate each note at the point in the write-up where it's relevant, rather than listing them separately at the end.

No narrative notes were found for this route. Skip narrative notes entirely rather than inventing local intel, and present the route on the strength of the other research.
```

Both are real output, not hand-written fixtures. The eval cases in `evals/cases/scenarios.yaml` use these same outputs as `narrative_prompt` values.

## Testing

- `bun test ./src/` — 86 pass, 2 pre-existing skips, 0 fail
- `bunx @biomejs/biome check .` — clean (two pre-existing warnings in `graphhopper.test.ts`, unrelated to this change)
- `bunx tsc --noEmit` — clean
- `bunx promptfoo eval` is known-broken in this environment (a pre-existing `@adaline` `ZodError`), so I confirmed both eval YAML files parse correctly with `js-yaml` instead of running the eval itself

Closes #24
