### PR TITLE
Add food stop planning skill

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -6,7 +6,7 @@ See [architecture.md](architecture.md) for orchestration model and design decisi
 
 ## Implementation Status {#implementation-status}
 
-History Analysis and Narrative Research have code today. The rest are design specs on the roadmap.
+History Analysis, Narrative Research, and Food Stop Planning have code today. The rest are design specs on the roadmap.
 
 | Skill | Status | Location |
 |-------|--------|----------|
@@ -14,7 +14,7 @@ History Analysis and Narrative Research have code today. The rest are design spe
 | Route Optimization | 🔜 Planned | - |
 | Climb Planning | 🔜 Planned | - |
 | Weather Planning | 🔜 Planned | - |
-| Food Stop Planning | 🔜 Planned | - |
+| Food Stop Planning | ✅ Implemented | `src/skills/food-stops/` |
 | Water Stop Planning | 🔜 Planned | - |
 | Narrative Research | ✅ Implemented | `src/skills/ride-reports/` |
 | Safety Assessment | 🔜 Planned | - |

--- a/src/skills/food-stops/evals/cases/scenarios.yaml
+++ b/src/skills/food-stops/evals/cases/scenarios.yaml
@@ -1,0 +1,79 @@
+- description: "Well-covered route with a lunch cafe open at arrival"
+  vars:
+    food_prompt: |-
+      Plan food stops along this route based on projected arrival times and business hours. Distinguish full meals from quick snacks.
+
+      Lunch at Cafe Roma: 20.0 km (arrive ~12:15 PM), open, 4.7★
+    stop_data: |
+      {
+        "stops": [
+          {
+            "place": { "name": "Cafe Roma", "rating": 4.7 },
+            "distanceAlongRouteM": 20020,
+            "arrivalTime": "2024-06-10T12:15:00Z",
+            "isOpenAtArrival": true,
+            "mealType": "meal",
+            "isBackup": false
+          }
+        ],
+        "totalDistanceM": 40030,
+        "averageSpeedKmh": 20
+      }
+    query: "Plan a 40km ride with a stop for lunch around the halfway point"
+  assert:
+    - type: llm-rubric
+      value: |
+        The response should:
+        - Reference Cafe Roma as the lunch stop
+        - Frame it as lunch, consistent with the ~12:15 PM arrival
+        - NOT suggest extra caution or backup planning, since it's open and highly rated
+
+- description: "Early-morning ride with the only cafe closed at projected arrival"
+  vars:
+    food_prompt: |-
+      Plan food stops along this route based on projected arrival times and business hours. Distinguish full meals from quick snacks.
+
+      Backup only, closed at arrival: Sunrise Bakery: 10.0 km (arrive ~6:00 AM), consider packing food for this stretch
+    stop_data: |
+      {
+        "stops": [
+          {
+            "place": { "name": "Sunrise Bakery", "rating": 4.4 },
+            "distanceAlongRouteM": 10010,
+            "arrivalTime": "2024-06-10T06:00:00Z",
+            "isOpenAtArrival": false,
+            "mealType": "meal",
+            "isBackup": true
+          }
+        ],
+        "totalDistanceM": 80060,
+        "averageSpeedKmh": 20
+      }
+    query: "Plan an early morning 80km ride starting before sunrise"
+  assert:
+    - type: llm-rubric
+      value: |
+        The response should:
+        - Flag that Sunrise Bakery will be closed at the projected 6:00 AM arrival
+        - Suggest either riding on to a later stop or packing food for that stretch
+        - NOT claim Sunrise Bakery will be open when the rider arrives
+
+- description: "No food places in the route corridor"
+  vars:
+    food_prompt: |-
+      Plan food stops along this route based on projected arrival times and business hours. Distinguish full meals from quick snacks.
+
+      No food stops found along the route corridor. Advise the rider to pack enough food for the full ride.
+    stop_data: |
+      {
+        "stops": [],
+        "totalDistanceM": 40030,
+        "averageSpeedKmh": 20
+      }
+    query: "Plan a 40km ride through a stretch with no listed food stops"
+  assert:
+    - type: llm-rubric
+      value: |
+        The response should:
+        - Clearly state that no food stops were found along the route
+        - Advise packing enough food for the full 40km ride

--- a/src/skills/food-stops/evals/prompt.txt
+++ b/src/skills/food-stops/evals/prompt.txt
@@ -1,0 +1,13 @@
+{{food_prompt}}
+
+## Food Stop Data
+
+```json
+{{stop_data}}
+```
+
+## Route Planning Request
+
+{{query}}
+
+Based on the food stop data above, provide meal/snack guidance for this request. Focus on where and when the rider should eat.

--- a/src/skills/food-stops/evals/promptfooconfig.yaml
+++ b/src/skills/food-stops/evals/promptfooconfig.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: "Food stop planning skill: does the prompt produce useful meal/snack guidance?"
+
+prompts:
+  - file://prompt.txt
+
+providers:
+  - id: anthropic:messages:claude-sonnet-5
+    config:
+      temperature: 0.0
+      max_tokens: 1024
+
+defaultTest:
+  options:
+    provider: anthropic:messages:claude-sonnet-5
+
+tests: file://cases/scenarios.yaml

--- a/src/skills/food-stops/food-stops.test.ts
+++ b/src/skills/food-stops/food-stops.test.ts
@@ -1,0 +1,325 @@
+import { describe, expect, test } from "bun:test";
+import { planFoodStops } from "./plan";
+import { buildFoodStopPrompt } from "./prompt";
+import type { FoodPlace, FoodStopPlanningInput, OpeningHours, RoutePoint } from "./types";
+
+const ALWAYS_OPEN: OpeningHours = {
+  0: [{ openMinute: 0, closeMinute: 1440 }],
+  1: [{ openMinute: 0, closeMinute: 1440 }],
+  2: [{ openMinute: 0, closeMinute: 1440 }],
+  3: [{ openMinute: 0, closeMinute: 1440 }],
+  4: [{ openMinute: 0, closeMinute: 1440 }],
+  5: [{ openMinute: 0, closeMinute: 1440 }],
+  6: [{ openMinute: 0, closeMinute: 1440 }],
+};
+
+// ~10 km apart in latitude, all at the same longitude.
+const route: RoutePoint[] = [
+  { lat: 37.0, lon: -122.0 },
+  { lat: 37.09, lon: -122.0 },
+  { lat: 37.18, lon: -122.0 },
+  { lat: 37.27, lon: -122.0 },
+  { lat: 37.36, lon: -122.0 },
+];
+
+const cafePlace: FoodPlace = {
+  id: "1",
+  name: "Trailhead Cafe",
+  lat: 37.0,
+  lon: -122.0,
+  rating: 4.2,
+  hours: ALWAYS_OPEN,
+};
+const dinerPlace: FoodPlace = {
+  id: "2",
+  name: "Midway Diner",
+  lat: 37.09,
+  lon: -122.001,
+  rating: 4.0,
+  hours: ALWAYS_OPEN,
+};
+const snackBarPlace: FoodPlace = {
+  id: "3",
+  name: "Junction Snack Bar",
+  lat: 37.18,
+  lon: -121.995,
+  rating: 3.8,
+  hours: ALWAYS_OPEN,
+};
+const bistroPlace: FoodPlace = {
+  id: "4",
+  name: "End Bistro",
+  lat: 37.36,
+  lon: -122.0,
+  rating: 4.9,
+  hours: ALWAYS_OPEN,
+};
+const farawayPlace: FoodPlace = {
+  id: "5",
+  name: "Faraway Diner",
+  lat: 37.15,
+  lon: -121.5,
+  hours: ALWAYS_OPEN,
+};
+
+const corridorStartTime = new Date("2024-01-15T09:00:00Z");
+
+function createInput(overrides?: Partial<FoodStopPlanningInput>): FoodStopPlanningInput {
+  return {
+    route,
+    places: [cafePlace, dinerPlace, snackBarPlace, bistroPlace, farawayPlace],
+    startTime: corridorStartTime,
+    ...overrides,
+  };
+}
+
+describe("planFoodStops corridor filtering and ordering", () => {
+  test("filters out places beyond the route corridor", () => {
+    const result = planFoodStops(createInput());
+    expect(result.stops.map((s) => s.place.id)).not.toContain(farawayPlace.id);
+  });
+
+  test("orders stops by distance along the route", () => {
+    const result = planFoodStops({ ...createInput(), targetSpacingM: 5000 });
+    const distances = result.stops.map((s) => s.distanceAlongRouteM);
+    expect(distances).toEqual([...distances].sort((a, b) => a - b));
+    expect(result.stops).toHaveLength(4);
+  });
+
+  test("respects a custom corridor distance", () => {
+    const result = planFoodStops({ ...createInput(), corridorDistanceM: 100 });
+    expect(result.stops.map((s) => s.place.id)).toEqual([cafePlace.id, bistroPlace.id]);
+  });
+});
+
+describe("planFoodStops spacing", () => {
+  test("applies the default target spacing of 40km", () => {
+    const result = planFoodStops(createInput());
+    expect(result.stops.map((s) => s.place.id)).toEqual([cafePlace.id, bistroPlace.id]);
+  });
+
+  test("thins closely spaced places with a custom target spacing", () => {
+    const result = planFoodStops({ ...createInput(), targetSpacingM: 15000 });
+    expect(result.stops.map((s) => s.place.id)).toEqual([
+      cafePlace.id,
+      snackBarPlace.id,
+      bistroPlace.id,
+    ]);
+  });
+
+  test("returns no stops when there are no places", () => {
+    const result = planFoodStops({ ...createInput(), places: [] });
+    expect(result.stops).toHaveLength(0);
+    expect(result.totalDistanceM).toBeGreaterThan(0);
+  });
+
+  test("resolves averageSpeedKmh in the output", () => {
+    expect(planFoodStops(createInput()).averageSpeedKmh).toBe(20);
+    expect(planFoodStops({ ...createInput(), averageSpeedKmh: 25 }).averageSpeedKmh).toBe(25);
+  });
+});
+
+describe("planFoodStops arrival time projection", () => {
+  const shortRoute: RoutePoint[] = [
+    { lat: 37.0, lon: -122.0 },
+    { lat: 37.09, lon: -122.0 },
+  ];
+  const halfwayPlace: FoodPlace = { id: "h", name: "Halfway Cafe", lat: 37.09, lon: -122.0 };
+  const startTime = new Date("2024-01-15T08:00:00Z");
+
+  function closeToMinutes(actual: Date, expected: Date, toleranceMinutes: number) {
+    expect(Math.abs(actual.getTime() - expected.getTime())).toBeLessThan(
+      toleranceMinutes * 60 * 1000,
+    );
+  }
+
+  test("projects arrival using the default averageSpeedKmh", () => {
+    const result = planFoodStops({ route: shortRoute, places: [halfwayPlace], startTime });
+    // ~10km at 20km/h -> ~30 minutes
+    closeToMinutes(result.stops[0].arrivalTime, new Date(startTime.getTime() + 30 * 60 * 1000), 2);
+  });
+
+  test("projects a later arrival with a slower averageSpeedKmh", () => {
+    const result = planFoodStops({
+      route: shortRoute,
+      places: [halfwayPlace],
+      startTime,
+      averageSpeedKmh: 10,
+    });
+    // ~10km at 10km/h -> ~60 minutes
+    closeToMinutes(result.stops[0].arrivalTime, new Date(startTime.getTime() + 60 * 60 * 1000), 2);
+  });
+});
+
+describe("planFoodStops meal classification and hours", () => {
+  const zeroRoute: RoutePoint[] = [
+    { lat: 37.0, lon: -122.0 },
+    { lat: 37.09, lon: -122.0 },
+  ];
+  const cornerDiner: FoodPlace = { id: "c", name: "Corner Diner", lat: 37.0, lon: -122.0 };
+
+  function planAtStart(startTime: Date, overrides?: Partial<FoodPlace>) {
+    return planFoodStops({
+      route: zeroRoute,
+      places: [{ ...cornerDiner, ...overrides }],
+      startTime,
+    });
+  }
+
+  test("classifies a breakfast-hour arrival as a meal", () => {
+    const result = planAtStart(new Date("2024-01-15T07:00:00Z"));
+    expect(result.stops[0].mealType).toBe("meal");
+  });
+
+  test("classifies a lunch-hour arrival as a meal", () => {
+    const result = planAtStart(new Date("2024-01-15T12:00:00Z"));
+    expect(result.stops[0].mealType).toBe("meal");
+  });
+
+  test("classifies a dinner-hour arrival as a meal", () => {
+    const result = planAtStart(new Date("2024-01-15T18:00:00Z"));
+    expect(result.stops[0].mealType).toBe("meal");
+  });
+
+  test("classifies an off-peak arrival as a snack", () => {
+    const result = planAtStart(new Date("2024-01-15T15:30:00Z"));
+    expect(result.stops[0].mealType).toBe("snack");
+  });
+
+  test("marks a stop open when the arrival falls within business hours", () => {
+    const result = planAtStart(new Date("2024-01-15T12:00:00Z"), { hours: ALWAYS_OPEN });
+    expect(result.stops[0].isOpenAtArrival).toBe(true);
+  });
+
+  test("marks a stop's hours unknown when no hours data is provided", () => {
+    const result = planAtStart(new Date("2024-01-15T12:00:00Z"));
+    expect(result.stops[0].isOpenAtArrival).toBe("unknown");
+  });
+});
+
+describe("planFoodStops backup gap-fill", () => {
+  // ~100 km, no other candidates in the route.
+  // Nearest-route-point matching only checks route vertices, so each place
+  // needs a vertex within the corridor distance.
+  function buildDenseRoute(segments: number): RoutePoint[] {
+    return Array.from({ length: segments + 1 }, (_, i) => ({ lat: 37.0 + i * 0.09, lon: -122.0 }));
+  }
+
+  const longRoute = buildDenseRoute(11); // ~110 km, vertices every ~10km
+  const sundayOnlyHours: OpeningHours = { 0: [{ openMinute: 0, closeMinute: 1440 }] };
+  const depotDeli: FoodPlace = {
+    id: "far",
+    name: "Depot Deli",
+    lat: longRoute[8].lat, // ~80 km
+    lon: -122.0,
+    rating: 4.0,
+    hours: sundayOnlyHours,
+  };
+  const startTime = new Date("2024-01-15T08:00:00Z"); // Monday
+
+  test("adds a backup stop for a large gap containing only closed candidates", () => {
+    const result = planFoodStops({ route: longRoute, places: [depotDeli], startTime });
+    expect(result.stops).toHaveLength(1);
+    expect(result.stops[0].place.id).toBe(depotDeli.id);
+    expect(result.stops[0].isBackup).toBe(true);
+    expect(result.stops[0].isOpenAtArrival).toBe(false);
+  });
+
+  test("does not add a backup stop when the gap is below the threshold", () => {
+    const shortRoute = buildDenseRoute(1); // ~10 km
+    const nearbyClosedPlace: FoodPlace = { ...depotDeli, lat: shortRoute[1].lat };
+    const result = planFoodStops({ route: shortRoute, places: [nearbyClosedPlace], startTime });
+    expect(result.stops).toHaveLength(0);
+  });
+
+  test("picks the highest-rated closed candidate as the backup", () => {
+    const lowRated: FoodPlace = {
+      id: "low",
+      name: "Low Rated Deli",
+      lat: longRoute[5].lat, // ~50 km
+      lon: -122.0,
+      rating: 3.0,
+      hours: sundayOnlyHours,
+    };
+    const highRated: FoodPlace = {
+      id: "high",
+      name: "High Rated Deli",
+      lat: longRoute[6].lat, // ~60 km
+      lon: -122.0,
+      rating: 4.8,
+      hours: sundayOnlyHours,
+    };
+    const result = planFoodStops({ route: longRoute, places: [lowRated, highRated], startTime });
+    expect(result.stops).toHaveLength(1);
+    expect(result.stops[0].place.id).toBe(highRated.id);
+  });
+});
+
+describe("buildFoodStopPrompt", () => {
+  const zeroRoute: RoutePoint[] = [
+    { lat: 37.0, lon: -122.0 },
+    { lat: 37.09, lon: -122.0 },
+  ];
+  const cornerDiner: FoodPlace = { id: "c", name: "Corner Diner", lat: 37.0, lon: -122.0 };
+
+  test("describes a meal stop with time, status, and rating", () => {
+    const output = planFoodStops({
+      route: zeroRoute,
+      places: [{ ...cornerDiner, rating: 4.6, hours: ALWAYS_OPEN }],
+      startTime: new Date("2024-01-15T12:00:00Z"),
+    });
+    const prompt = buildFoodStopPrompt(output);
+    expect(prompt).toContain("Lunch at Corner Diner: 0.0 km (arrive ~12:00 PM), open, 4.6★");
+  });
+
+  test("labels an off-peak stop as a snack", () => {
+    const output = planFoodStops({
+      route: zeroRoute,
+      places: [{ ...cornerDiner, hours: ALWAYS_OPEN }],
+      startTime: new Date("2024-01-15T15:30:00Z"),
+    });
+    const prompt = buildFoodStopPrompt(output);
+    expect(prompt).toContain("Snack at Corner Diner");
+  });
+
+  test("flags unknown hours instead of claiming a stop is open", () => {
+    const output = planFoodStops({
+      route: zeroRoute,
+      places: [cornerDiner],
+      startTime: new Date("2024-01-15T12:00:00Z"),
+    });
+    const prompt = buildFoodStopPrompt(output);
+    expect(prompt).toContain("hours unknown, verify before relying on it");
+    expect(prompt).not.toContain(", open");
+  });
+
+  test("phrases a backup stop as closed and suggests packing food", () => {
+    const longRoute: RoutePoint[] = Array.from({ length: 12 }, (_, i) => ({
+      lat: 37.0 + i * 0.09,
+      lon: -122.0,
+    })); // ~110 km, vertices every ~10km
+    const depotDeli: FoodPlace = {
+      id: "far",
+      name: "Depot Deli",
+      lat: longRoute[8].lat, // ~80 km
+      lon: -122.0,
+      rating: 4.0,
+      hours: { 0: [{ openMinute: 0, closeMinute: 1440 }] },
+    };
+    const output = planFoodStops({
+      route: longRoute,
+      places: [depotDeli],
+      startTime: new Date("2024-01-15T08:00:00Z"),
+    });
+    const prompt = buildFoodStopPrompt(output);
+    expect(prompt).toContain("Backup only, closed at arrival: Depot Deli");
+    expect(prompt).toContain("consider packing food for this stretch");
+  });
+
+  test("advises packing food when no stops are found", () => {
+    const output = planFoodStops({ route, places: [], startTime: corridorStartTime });
+    const prompt = buildFoodStopPrompt(output);
+    expect(prompt).toContain("No food stops found");
+    expect(prompt).toContain("pack enough food");
+  });
+});

--- a/src/skills/food-stops/index.ts
+++ b/src/skills/food-stops/index.ts
@@ -1,0 +1,11 @@
+export { planFoodStops } from "./plan";
+export { buildFoodStopPrompt } from "./prompt";
+export type {
+  FoodPlace,
+  FoodStopPlanningInput,
+  FoodStopPlanningOutput,
+  FoodStopRecommendation,
+  MealType,
+  OpeningHours,
+  RoutePoint,
+} from "./types";

--- a/src/skills/food-stops/plan.ts
+++ b/src/skills/food-stops/plan.ts
@@ -1,0 +1,204 @@
+import type {
+  FoodPlace,
+  FoodStopPlanningInput,
+  FoodStopPlanningOutput,
+  FoodStopRecommendation,
+  MealType,
+  OpeningHours,
+  RoutePoint,
+} from "./types";
+
+const DEFAULT_AVERAGE_SPEED_KMH = 20;
+const DEFAULT_CORRIDOR_DISTANCE_M = 500;
+const DEFAULT_TARGET_SPACING_M = 40000;
+const BACKUP_GAP_MULTIPLIER = 1.5;
+
+const MINUTES_PER_HOUR = 60;
+const MEAL_WINDOWS = [
+  { startMinute: 6 * MINUTES_PER_HOUR, endMinute: 10 * MINUTES_PER_HOUR }, // breakfast
+  { startMinute: 11 * MINUTES_PER_HOUR, endMinute: 14 * MINUTES_PER_HOUR }, // lunch
+  { startMinute: 17 * MINUTES_PER_HOUR, endMinute: 20 * MINUTES_PER_HOUR }, // dinner
+];
+
+function haversineM(a: RoutePoint, b: RoutePoint): number {
+  const R = 6371000;
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const dLat = toRad(b.lat - a.lat);
+  const dLon = toRad(b.lon - a.lon);
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(a.lat)) * Math.cos(toRad(b.lat)) * Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(h), Math.sqrt(1 - h));
+}
+
+function cumulativeDistances(route: RoutePoint[]): number[] {
+  const distances = [0];
+  for (let i = 1; i < route.length; i++) {
+    distances.push(distances[i - 1] + haversineM(route[i - 1], route[i]));
+  }
+  return distances;
+}
+
+function nearestRoutePoint(
+  place: RoutePoint,
+  route: RoutePoint[],
+  distances: number[],
+): { distanceAlongRouteM: number; distanceFromRouteM: number } {
+  let nearestIndex = 0;
+  let nearestDistanceM = Number.POSITIVE_INFINITY;
+
+  for (let i = 0; i < route.length; i++) {
+    const distanceM = haversineM(place, route[i]);
+    if (distanceM < nearestDistanceM) {
+      nearestDistanceM = distanceM;
+      nearestIndex = i;
+    }
+  }
+
+  return { distanceAlongRouteM: distances[nearestIndex], distanceFromRouteM: nearestDistanceM };
+}
+
+interface ProjectedCandidate {
+  place: FoodPlace;
+  distanceAlongRouteM: number;
+  distanceFromRouteM: number;
+  arrivalTime: Date;
+  isOpenAtArrival: boolean | "unknown";
+  mealType: MealType;
+}
+
+function findCorridorCandidates(
+  input: FoodStopPlanningInput,
+  distances: number[],
+): Array<{ place: FoodPlace; distanceAlongRouteM: number; distanceFromRouteM: number }> {
+  const corridorDistanceM = input.corridorDistanceM ?? DEFAULT_CORRIDOR_DISTANCE_M;
+
+  return input.places
+    .map((place) => ({ place, ...nearestRoutePoint(place, input.route, distances) }))
+    .filter((candidate) => candidate.distanceFromRouteM <= corridorDistanceM)
+    .sort((a, b) => a.distanceAlongRouteM - b.distanceAlongRouteM);
+}
+
+function projectArrivalTime(
+  startTime: Date,
+  distanceAlongRouteM: number,
+  averageSpeedKmh: number,
+): Date {
+  const hours = distanceAlongRouteM / 1000 / averageSpeedKmh;
+  return new Date(startTime.getTime() + hours * 60 * 60 * 1000);
+}
+
+function isOpenAt(hours: OpeningHours | undefined, date: Date): boolean | "unknown" {
+  if (!hours) return "unknown";
+
+  const windows = hours[date.getUTCDay()];
+  if (!windows) return false;
+
+  const minuteOfDay = date.getUTCHours() * MINUTES_PER_HOUR + date.getUTCMinutes();
+  return windows.some((w) => minuteOfDay >= w.openMinute && minuteOfDay < w.closeMinute);
+}
+
+function classifyMeal(arrivalTime: Date): MealType {
+  const minuteOfDay = arrivalTime.getUTCHours() * MINUTES_PER_HOUR + arrivalTime.getUTCMinutes();
+  const isMealTime = MEAL_WINDOWS.some(
+    (w) => minuteOfDay >= w.startMinute && minuteOfDay < w.endMinute,
+  );
+  return isMealTime ? "meal" : "snack";
+}
+
+function projectCandidates(
+  candidates: Array<{ place: FoodPlace; distanceAlongRouteM: number; distanceFromRouteM: number }>,
+  startTime: Date,
+  averageSpeedKmh: number,
+): ProjectedCandidate[] {
+  return candidates.map((candidate) => {
+    const arrivalTime = projectArrivalTime(
+      startTime,
+      candidate.distanceAlongRouteM,
+      averageSpeedKmh,
+    );
+    return {
+      ...candidate,
+      arrivalTime,
+      isOpenAtArrival: isOpenAt(candidate.place.hours, arrivalTime),
+      mealType: classifyMeal(arrivalTime),
+    };
+  });
+}
+
+function selectSpacedStops(
+  candidates: ProjectedCandidate[],
+  targetSpacingM: number,
+): ProjectedCandidate[] {
+  const stops: ProjectedCandidate[] = [];
+  let lastStopDistanceM = Number.NEGATIVE_INFINITY;
+
+  for (const candidate of candidates) {
+    if (candidate.isOpenAtArrival === false) continue;
+    if (candidate.distanceAlongRouteM - lastStopDistanceM < targetSpacingM) continue;
+    stops.push(candidate);
+    lastStopDistanceM = candidate.distanceAlongRouteM;
+  }
+
+  return stops;
+}
+
+function findBackupStops(
+  candidates: ProjectedCandidate[],
+  selectedStops: ProjectedCandidate[],
+  targetSpacingM: number,
+  totalDistanceM: number,
+): ProjectedCandidate[] {
+  const gapBoundaries = [0, ...selectedStops.map((s) => s.distanceAlongRouteM), totalDistanceM];
+  const backups: ProjectedCandidate[] = [];
+
+  for (let i = 0; i < gapBoundaries.length - 1; i++) {
+    const gapStartM = gapBoundaries[i];
+    const gapEndM = gapBoundaries[i + 1];
+    if (gapEndM - gapStartM <= BACKUP_GAP_MULTIPLIER * targetSpacingM) continue;
+
+    const closedInGap = candidates.filter(
+      (c) =>
+        c.isOpenAtArrival === false &&
+        c.distanceAlongRouteM > gapStartM &&
+        c.distanceAlongRouteM < gapEndM,
+    );
+    if (closedInGap.length === 0) continue;
+
+    const highestRated = closedInGap.reduce((best, candidate) =>
+      (candidate.place.rating ?? -Infinity) > (best.place.rating ?? -Infinity) ? candidate : best,
+    );
+    backups.push(highestRated);
+  }
+
+  return backups;
+}
+
+export function planFoodStops(input: FoodStopPlanningInput): FoodStopPlanningOutput {
+  const distances = cumulativeDistances(input.route);
+  const totalDistanceM = distances[distances.length - 1] ?? 0;
+  const averageSpeedKmh = input.averageSpeedKmh ?? DEFAULT_AVERAGE_SPEED_KMH;
+  const targetSpacingM = input.targetSpacingM ?? DEFAULT_TARGET_SPACING_M;
+
+  const candidates = projectCandidates(
+    findCorridorCandidates(input, distances),
+    input.startTime,
+    averageSpeedKmh,
+  );
+  const selectedStops = selectSpacedStops(candidates, targetSpacingM);
+  const backupStops = findBackupStops(candidates, selectedStops, targetSpacingM, totalDistanceM);
+
+  const stops: FoodStopRecommendation[] = [...selectedStops, ...backupStops]
+    .sort((a, b) => a.distanceAlongRouteM - b.distanceAlongRouteM)
+    .map((candidate) => ({
+      place: candidate.place,
+      distanceAlongRouteM: candidate.distanceAlongRouteM,
+      distanceFromRouteM: candidate.distanceFromRouteM,
+      arrivalTime: candidate.arrivalTime,
+      isOpenAtArrival: candidate.isOpenAtArrival,
+      mealType: candidate.mealType,
+      isBackup: backupStops.includes(candidate),
+    }));
+
+  return { stops, totalDistanceM, averageSpeedKmh };
+}

--- a/src/skills/food-stops/prompt.ts
+++ b/src/skills/food-stops/prompt.ts
@@ -1,0 +1,50 @@
+import type { FoodStopPlanningOutput, FoodStopRecommendation } from "./types";
+
+const corePrompt = `Plan food stops along this route based on projected arrival times and business hours. Distinguish full meals from quick snacks.`;
+
+function coverageContext(output: FoodStopPlanningOutput): string {
+  if (output.stops.length > 0) return "";
+  return "No food stops found along the route corridor. Advise the rider to pack enough food for the full ride.";
+}
+
+function formatTime(date: Date): string {
+  const hour24 = date.getUTCHours();
+  const minute = date.getUTCMinutes().toString().padStart(2, "0");
+  const period = hour24 >= 12 ? "PM" : "AM";
+  const hour12 = hour24 % 12 === 0 ? 12 : hour24 % 12;
+  return `${hour12}:${minute} ${period}`;
+}
+
+function mealLabel(stop: FoodStopRecommendation): string {
+  if (stop.mealType === "snack") return "Snack";
+  const hour = stop.arrivalTime.getUTCHours();
+  if (hour < 11) return "Breakfast";
+  if (hour < 17) return "Lunch";
+  return "Dinner";
+}
+
+function describeStop(stop: FoodStopRecommendation): string {
+  const distanceKm = (stop.distanceAlongRouteM / 1000).toFixed(1);
+  const arrival = formatTime(stop.arrivalTime);
+
+  if (stop.isBackup) {
+    return `Backup only, closed at arrival: ${stop.place.name}: ${distanceKm} km (arrive ~${arrival}), consider packing food for this stretch`;
+  }
+
+  const status =
+    stop.isOpenAtArrival === "unknown" ? "hours unknown, verify before relying on it" : "open";
+  const rating = stop.place.rating !== undefined ? `, ${stop.place.rating.toFixed(1)}★` : "";
+
+  return `${mealLabel(stop)} at ${stop.place.name}: ${distanceKm} km (arrive ~${arrival}), ${status}${rating}`;
+}
+
+function stopsContext(output: FoodStopPlanningOutput): string {
+  if (output.stops.length === 0) return "";
+  return output.stops.map(describeStop).join("\n");
+}
+
+export function buildFoodStopPrompt(output: FoodStopPlanningOutput): string {
+  const sections = [corePrompt, coverageContext(output), stopsContext(output)].filter(Boolean);
+
+  return sections.join("\n\n");
+}

--- a/src/skills/food-stops/types.ts
+++ b/src/skills/food-stops/types.ts
@@ -1,0 +1,50 @@
+export interface RoutePoint {
+  lat: number;
+  lon: number;
+}
+
+export interface OpeningHours {
+  /** 0 = Sunday .. 6 = Saturday. Missing day = closed. */
+  [dayOfWeek: number]: Array<{ openMinute: number; closeMinute: number }>;
+}
+
+export interface FoodPlace {
+  id: string;
+  name: string;
+  lat: number;
+  lon: number;
+  rating?: number;
+  /** Undefined when the source didn't report hours. */
+  hours?: OpeningHours;
+}
+
+export type MealType = "meal" | "snack";
+
+export interface FoodStopPlanningInput {
+  route: RoutePoint[];
+  places: FoodPlace[];
+  startTime: Date;
+  /** Average riding speed in km/h, used to project arrival times. Default 20. */
+  averageSpeedKmh?: number;
+  /** Max distance (meters) from the route to consider a place. Default 500m. */
+  corridorDistanceM?: number;
+  /** Target spacing (meters) between recommended stops. Default 40000m. */
+  targetSpacingM?: number;
+}
+
+export interface FoodStopRecommendation {
+  place: FoodPlace;
+  distanceAlongRouteM: number;
+  distanceFromRouteM: number;
+  arrivalTime: Date;
+  isOpenAtArrival: boolean | "unknown";
+  mealType: MealType;
+  /** Included despite being closed, to fill an otherwise-empty gap. */
+  isBackup: boolean;
+}
+
+export interface FoodStopPlanningOutput {
+  stops: FoodStopRecommendation[];
+  totalDistanceM: number;
+  averageSpeedKmh: number;
+}


### PR DESCRIPTION
Adds a food stop planning skill, following the `water-stops` skill's shape: pure logic in `plan.ts`, a prompt builder in `prompt.ts`, and colocated evals. It filters places to a route corridor, projects arrival time from an average speed, classifies each stop as a meal or snack by arrival hour, and checks a place's opening hours against that arrival time.

Closes #12

## Design Notes

This skill owns a minimal `FoodPlace` type instead of depending on the in-flight Google Maps MCP work (#11). An adapter can map Google Places responses onto `FoodPlace` once that lands, so this skill doesn't block on it.

Spacing selection walks the sorted corridor candidates and skips any place whose hours put it closed at arrival, so a closed place never displaces an open one nearby. Separately, if a gap between selected stops (or from the route start/end) exceeds 1.5x the target spacing and contains no open candidate, the highest-rated closed place in that gap is added back as `isBackup: true`, so a genuinely food-desert stretch still surfaces its best (if inconvenient) option instead of going silent.

Hours lookups use UTC day/hour rather than local time, matching the single-timezone assumption below and keeping tests deterministic regardless of where they run.

### Scope Cuts

- No cyclist-friendliness signals (outdoor seating, etc.)
- No live "open now" checks, only the place's stored hours
- Single-timezone assumption, no per-stop local time conversion
- No overnight-spanning hours windows (a close time before the open time on the same day isn't handled)
- Flat `averageSpeedKmh`, no terrain-based adjustment
- No multi-day rides
- Food only. Water refills are handled by `water-stops` (#14, merged)

## Demonstration

Real `buildFoodStopPrompt` output for an early-morning ride where the only candidate is closed at the projected arrival, so it surfaces as a flagged backup rather than dropping silently:

```
Plan food stops along this route based on projected arrival times and business hours. Distinguish full meals from quick snacks.

Backup only, closed at arrival: Sunrise Bakery: 10.0 km (arrive ~6:00 AM), consider packing food for this stretch
```

And a well-covered lunch stop:

```
Plan food stops along this route based on projected arrival times and business hours. Distinguish full meals from quick snacks.

Lunch at Cafe Roma: 20.0 km (arrive ~12:15 PM), open, 4.7★
```

## Testing

- `bun test ./src/`: 100 tests pass, 23 of them new for `food-stops`. 2 pre-existing skips are unrelated to this change.
- `bunx tsc --noEmit`: clean.
- `bunx @biomejs/biome check .`: no errors. Two pre-existing warnings remain in `graphhopper.test.ts` and the `biome.json` schema version, unrelated to this change.
- `bunx promptfoo eval` isn't runnable in this environment (pre-existing `@adaline` `ZodError`), so I validated the eval YAML parses and hand-verified the three scenarios' `stop_data`/`food_prompt` vars against real `planFoodStops`/`buildFoodStopPrompt` output
